### PR TITLE
Fix admin DB env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This project automates the synchronization of Ringover calls with OpenAI process
 ```bash
 composer install
 cp .env.example .env
-# Edit .env with your database and API credentials
+# Edit `.env` and set `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` and `DB_PASS`
+# along with your API credentials
 php -S localhost:8000 -t public
 ```
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -22,7 +22,7 @@ if (file_exists($envFile)) {
     }
 }
 
-$requiredEnv = ['DB_HOST','DB_PORT','DB_DATABASE','DB_USERNAME','DB_PASSWORD'];
+$requiredEnv = ['DB_HOST','DB_PORT','DB_NAME','DB_USER','DB_PASS'];
 foreach ($requiredEnv as $key) {
     if (empty($_ENV[$key])) {
         http_response_code(500);
@@ -34,9 +34,9 @@ foreach ($requiredEnv as $key) {
 $dbConfig = [
     'host'     => $_ENV['DB_HOST'],
     'port'     => $_ENV['DB_PORT'],
-    'database' => $_ENV['DB_DATABASE'],
-    'username' => $_ENV['DB_USERNAME'],
-    'password' => $_ENV['DB_PASSWORD']
+    'database' => $_ENV['DB_NAME'],
+    'username' => $_ENV['DB_USER'],
+    'password' => $_ENV['DB_PASS']
 ];
 
 /* ---------- Helpers ---------- */

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,9 +6,11 @@
    ```
 2. **Create the environment configuration**.
    ```bash
-   cp .env.example .env
-   ```
-   Edit `.env` with your database credentials and API tokens.
+cp .env.example .env
+```
+   Edit `.env` and configure the database variables:
+   `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`.
+   Add your API tokens as needed.
 3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server.
 4. **Launch the built-in PHP web server** for local testing.
    ```bash

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -12,7 +12,8 @@ Flujos Dimension sincroniza llamadas de Ringover y analiza las grabaciones con O
 ## Instalación rápida
 
 1. Ejecuta `composer install` para descargar las dependencias.
-2. Copia `.env.example` a `.env` y ajusta tus credenciales.
+2. Copia `.env.example` a `.env` y configura `DB_HOST`, `DB_PORT`, `DB_NAME`,
+   `DB_USER` y `DB_PASS`, además de tus tokens de API.
 3. Importa `database/flujodimen_db.sql` en tu servidor MySQL/MariaDB.
 4. Inicia el servidor con `php -S localhost:8000 -t public`.
 


### PR DESCRIPTION
## Summary
- read DB credentials from `DB_NAME`, `DB_USER` and `DB_PASS` in `admin/index.php`
- clarify required env vars in README and install docs

## Testing
- `php -l admin/index.php`
- `composer install`
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l` *(fails: parse error in api/index.php)*

------
https://chatgpt.com/codex/tasks/task_e_687fc86fd284832a96ebb653526073e9