### PR TITLE
Fix missing phone check in push_pipedrive

### DIFF
--- a/admin/api/push_pipedrive.php
+++ b/admin/api/push_pipedrive.php
@@ -20,7 +20,12 @@ $pending = $repo->callsNotInCrm();   // SELECT * WHERE crm_synced=0
 $created = 0;
 
 foreach ($pending as $c) {
-    $personId = $crm->findPersonByPhone($c['phone_number']) ?? null;
+    // Skip Pipedrive person search when no phone number is available
+    if (!empty($c['phone_number'])) {
+        $personId = $crm->findPersonByPhone($c['phone_number']) ?? null;
+    } else {
+        $personId = null;
+    }
     $dealId   = $crm->createOrUpdateDeal([
         'title'     => 'Call '.$c['id'],
         'value'     => 0,


### PR DESCRIPTION
## Summary
- avoid unnecessary Pipedrive lookup when call has no phone number

## Testing
- `composer validate --no-check-all --strict`
- `php -l admin/api/push_pipedrive.php`


------
https://chatgpt.com/codex/tasks/task_e_687fdfbcc3b4832aa5289a6a435be033