### PR TITLE
Remove unused imports in admin index

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -8,9 +8,6 @@ define('ADMIN_ACCESS', true);
 error_reporting(E_ALL);
 ini_set('display_errors', 0);
 ini_set('log_errors', 1);
-use FlujosDimension\Core\Config;
-use FlujosDimension\Core\Database;
-use FlujosDimension\Core\JWT;
 /* ---------- Carga .env ---------- */
 $envFile = dirname(__DIR__) . '/.env';
 if (file_exists($envFile)) {


### PR DESCRIPTION
## Summary
- clean up `admin/index.php` by removing unused `use` statements

## Testing
- `php -l admin/index.php`

------
https://chatgpt.com/codex/tasks/task_e_687fe6d96d60832a937d35f338180735