### PR TITLE
Remove unused imports from admin index

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -8,9 +8,6 @@ define('ADMIN_ACCESS', true);
 error_reporting(E_ALL);
 ini_set('display_errors', 0);
 ini_set('log_errors', 1);
-use FlujosDimension\Core\Config;
-use FlujosDimension\Core\Database;
-use FlujosDimension\Core\JWT;
 /* ---------- Carga .env ---------- */
 $envFile = dirname(__DIR__) . '/.env';
 if (file_exists($envFile)) {


### PR DESCRIPTION
## Summary
- clean up unused `use` statements in admin/index.php

## Testing
- `php -l admin/index.php`

------
https://chatgpt.com/codex/tasks/task_e_687fe73712d0832a9483f60fc0c512c7