### PR TITLE
Fix deploy workflow action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run tests
         run: vendor/bin/phpunit
       - name: Upload via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}


### PR DESCRIPTION
## Summary
- use `SamKirkland/FTP-Deploy-Action` tag `v4.3.5` so the workflow can resolve the action

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_687ff7fe5990832a9e0d7833026d7492