### PR TITLE
Add database alias

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -77,6 +77,8 @@ private function registerServices(): void
 
     // Conexión PDO única
     $this->container->bind(PDO::class, fn () => $this->getDatabaseConnection());
+    // Alias para acceder a la base de datos por nombre
+    $this->container->alias(PDO::class, 'database');
 
     /* ---------- Logger ---------- */
     $this->container->bind('logger', fn () =>


### PR DESCRIPTION
## Summary
- alias the PDO binding to 'database' so controllers and models can retrieve the connection by name

## Testing
- `composer exec -- phpunit --testsuite default`

------
https://chatgpt.com/codex/tasks/task_e_688032419f38832ab40a6cba85e65bd3