### PR TITLE
Add unit tests for services and routing

### DIFF
--- a/tests/DashboardControllerTest.php
+++ b/tests/DashboardControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Controllers\DashboardController;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Core\Response;
+use FlujosDimension\Services\AnalyticsService;
+use FlujosDimension\Repositories\CallRepository;
+use FlujosDimension\Services\OpenAIService;
+use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+class DashboardDbStub {
+    private array $results; private int $i = 0;
+    public function __construct(array $results) { $this->results = $results; }
+    public function prepare($sql) { return new class($this->results[$this->i++]) {
+        private array $r; public function __construct($r){$this->r=$r;} public function execute($p=[]){} public function fetch(){return $this->r;}
+    }; }
+    public function query($sql) { return new class($this->results[$this->i++]) {
+        private array $r; public function __construct($r){$this->r=$r;} public function fetchAll(){return $this->r;} public function fetch(){return $this->r;}
+    }; }
+}
+class DummyLogger { public function error($m){} }
+
+class DummyRingover extends RingoverService {
+    public function __construct() {}
+}
+
+class DashboardControllerTest extends TestCase
+{
+    public function testQuickStatsReturnsJson()
+    {
+        $container = new Container();
+        $db = new DashboardDbStub([
+            ['calls_today'=>5,'answered_today'=>3,'calls_last_hour'=>2,'avg_duration_today'=>30],
+            ['calls_yesterday'=>4,'answered_yesterday'=>2]
+        ]);
+        $container->instance('logger', new DummyLogger());
+        $container->instance('config', []);
+        $container->instance('database', $db);
+        $pdo = new \PDO('sqlite::memory:');
+        $repo = new CallRepository($pdo);
+        $openai = new OpenAIService(new HttpClient(['handler' => HandlerStack::create(new MockHandler())]), 'k');
+        $analytics = new AnalyticsService($repo, $openai);
+        $container->instance('analyticsService', $analytics);
+        $container->instance('ringoverService', new DummyRingover());
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => '/'];
+        $controller = new DashboardController($container, new Request());
+        $response = $controller->quickStats();
+        $this->assertInstanceOf(Response::class, $response);
+        $ref = new \ReflectionClass($response);
+        $prop = $ref->getProperty('content');
+        $prop->setAccessible(true);
+        $data = json_decode($prop->getValue($response), true);
+        $this->assertTrue($data['success']);
+        $this->assertSame(5, $data['data']['today']['total_calls']);
+    }
+}

--- a/tests/Fixtures/RouteController.php
+++ b/tests/Fixtures/RouteController.php
@@ -1,0 +1,13 @@
+<?php
+namespace FlujosDimension\Controllers;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Core\Response;
+class RouteController
+{
+    public function __construct(Container $c, Request $r) {}
+    public function greet(string $name): Response
+    {
+        return new Response("Hello $name");
+    }
+}

--- a/tests/JwtTest.php
+++ b/tests/JwtTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Core\JWT;
+use FlujosDimension\Core\Database;
+use FlujosDimension\Core\Config;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class TokenDbStub {
+    public int $inserts = 0;
+    public int $selects = 0;
+    public int $updates = 0;
+    public function insert($q,$p=[]) { $this->inserts++; }
+    public function selectOne($q,$p=[]) { $this->selects++; return ['id'=>1]; }
+    public function update($q,$p=[]) { $this->updates++; return 1; }
+    public function delete($q,$p=[]) { return 0; }
+    public function select($q,$p=[]) { return []; }
+}
+
+class JwtTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $config = Config::getInstance();
+        $config->set('JWT_SECRET', 'secret');
+        $config->set('JWT_EXPIRATION_HOURS', '1');
+        $ref = new ReflectionClass(Database::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, new TokenDbStub());
+    }
+
+    public function testGenerateAndValidateToken()
+    {
+        $jwt = new JWT();
+        $token = $jwt->generateToken(['user_id' => 5]);
+        $this->assertMatchesRegularExpression('/^[^.]+\.[^.]+\.[^.]+$/', $token);
+        $payload = $jwt->validateToken($token);
+        $this->assertSame(5, $payload['user_id']);
+    }
+}

--- a/tests/OpenAIServiceTest.php
+++ b/tests/OpenAIServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Services\OpenAIService;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+
+class OpenAIServiceTest extends TestCase
+{
+    public function testChatSendsRequest()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['choices' => [['message' => ['content' => 'ok']]]]))
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $http = new HttpClient(['handler' => $stack]);
+        $service = new OpenAIService($http, 'key', 'model-x');
+        $result = $service->chat([['role'=>'user','content'=>'hi']], ['temperature' => 0]);
+        $this->assertSame('ok', $result['choices'][0]['message']['content']);
+        $this->assertCount(1, $history);
+        $req = $history[0]['request'];
+        $this->assertSame('POST', $req->getMethod());
+        $this->assertSame('https://api.openai.com/v1/chat/completions', (string)$req->getUri());
+        $this->assertSame('Bearer key', $req->getHeaderLine('Authorization'));
+    }
+}

--- a/tests/RingoverServiceTest.php
+++ b/tests/RingoverServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Core\Container;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+
+class RingoverServiceTest extends TestCase
+{
+    public function testGetCallsPagination()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Link' => '<https://api.test/calls?page=2>; rel="next"'], json_encode(['data' => [['id' => 1]]])),
+            new Response(200, [], json_encode(['data' => [['id' => 2]]]))
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $http = new HttpClient(['handler' => $stack]);
+        $container = new Container();
+        $container->instance('httpClient', $http);
+        $container->instance('config', ['RINGOVER_API_TOKEN' => 't', 'RINGOVER_API_URL' => 'https://api.test']);
+        $service = new RingoverService($container);
+        $calls = iterator_to_array($service->getCalls(new DateTimeImmutable('2024-01-01T00:00:00Z')));
+        $this->assertCount(2, $calls);
+        $this->assertCount(2, $history);
+        $first = $history[0]['request'];
+        $this->assertSame('GET', $first->getMethod());
+        $this->assertStringContainsString('date_start', $first->getUri()->getQuery());
+    }
+
+    public function testDownloadRecording()
+    {
+        $mock = new MockHandler([new Response(200, [], 'audio')]);
+        $stack = HandlerStack::create($mock);
+        $http = new HttpClient(['handler' => $stack]);
+        $container = new Container();
+        $container->instance('httpClient', $http);
+        $container->instance('config', ['RINGOVER_API_TOKEN' => 't']);
+        $service = new RingoverService($container);
+        $dir = sys_get_temp_dir().'/ringtest';
+        $path = $service->downloadRecording('https://files.test/rec.mp3', $dir);
+        $this->assertFileExists($path);
+        $this->assertSame('audio', file_get_contents($path));
+        unlink($path);
+        rmdir($dir);
+    }
+}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Core\Router;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Core\Response;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__.'/Fixtures/RouteController.php';
+
+
+class RouterTest extends TestCase
+{
+    public function testDispatchMatchesRoute()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/hi/Alice';
+        $router = new Router(new \FlujosDimension\Core\Container());
+        $router->get('/hi/{name}', 'RouteController@greet');
+        $response = $router->dispatch(new Request());
+        $this->assertInstanceOf(Response::class, $response);
+        $ref = new \ReflectionClass($response);
+        $prop = $ref->getProperty('content');
+        $prop->setAccessible(true);
+        $this->assertSame('Hello Alice', $prop->getValue($response));
+    }
+}


### PR DESCRIPTION
## Summary
- add fixtures for router tests
- test RingoverService pagination and download
- test OpenAIService POST request
- test custom routing
- test JWT token generation
- test DashboardController quick stats

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688032521640832aa66ab9456a0d3de1