### PR TITLE
Bind JWT and cache services

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FlujosDimension\Core;
 
-use FlujosDimension\Core\{Config,Database,JWT};
+use FlujosDimension\Core\{Config,Database,JWT,CacheManager};
 /**
  * Aplicación Principal - Flujos Dimension v4.2
  * Migrado y mejorado desde v3
@@ -84,6 +84,16 @@ private function registerServices(): void
     $this->container->bind('logger', fn () =>
         new \FlujosDimension\Core\Logger(dirname(__DIR__, 2) . '/storage/logs')
     );
+
+    /* ---------- JWT Service ---------- */
+    $this->container->bind(JWT::class, fn () => new JWT());
+    $this->container->alias(JWT::class, 'jwtService');
+
+    /* ---------- Cache Manager ---------- */
+    $this->container->bind(CacheManager::class, fn () =>
+        new CacheManager(dirname(__DIR__, 2) . '/storage/cache')
+    );
+    $this->container->alias(CacheManager::class, 'cache');
 
     /* ---------- HttpClient (Guzzle + retry) ---------- */
     $this->container->bind(

--- a/bootstrap/env.php
+++ b/bootstrap/env.php
@@ -1,0 +1,3 @@
+<?php
+// Minimal variables for tests
+$_ENV['JWT_SECRET'] = 'testsecret';

--- a/tests/ApplicationServicesTest.php
+++ b/tests/ApplicationServicesTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Core\Application;
+use FlujosDimension\Core\JWT;
+use FlujosDimension\Core\CacheManager;
+
+class ApplicationServicesTest extends TestCase
+{
+    public function testJwtAndCacheBindings()
+    {
+        $app = new Application();
+        $jwt = $app->service('jwtService');
+        $cache = $app->service('cache');
+
+        $this->assertInstanceOf(JWT::class, $jwt);
+        $this->assertInstanceOf(CacheManager::class, $cache);
+
+        $cache->set('foo', 'bar', 1);
+        $this->assertSame('bar', $cache->get('foo'));
+
+        restore_error_handler();
+        restore_exception_handler();
+    }
+}


### PR DESCRIPTION
## Summary
- bind `FlujosDimension\Core\JWT` as `jwtService`
- bind `FlujosDimension\Core\CacheManager` as `cache`
- add minimal `bootstrap/env.php` for tests
- ensure services are accessible via new test

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880949f3550832a817a4354e129ca36