### PR TITLE
Fix nullable param types

### DIFF
--- a/app/Core/Logger.php
+++ b/app/Core/Logger.php
@@ -19,7 +19,7 @@ class Logger
         'critical' => 4
     ];
     
-    public function __construct(string $logDir = null, string $defaultLevel = 'info')
+    public function __construct(?string $logDir = null, string $defaultLevel = 'info')
     {
         $this->logDir = $logDir ?: dirname(__DIR__, 2) . '/storage/logs';
         $this->defaultLevel = $defaultLevel;
@@ -139,7 +139,7 @@ class Logger
     /**
      * Log de sincronización
      */
-    public function sync(string $source, string $action, bool $success, int $recordsProcessed = 0, string $error = null): void
+    public function sync(string $source, string $action, bool $success, int $recordsProcessed = 0, ?string $error = null): void
     {
         $status = $success ? 'SUCCESS' : 'FAILED';
         $message = "Sync {$source} - {$action} - {$status}";

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -154,7 +154,7 @@ abstract class BaseModel
     /**
      * Obtener registros con paginación
      */
-    public function paginate(int $page = 1, int $perPage = 20, string $orderBy = null, string $direction = 'DESC'): array
+    public function paginate(int $page = 1, int $perPage = 20, ?string $orderBy = null, string $direction = 'DESC'): array
     {
         $orderBy = $orderBy ?: $this->primaryKey;
         $direction = strtoupper($direction) === 'ASC' ? 'ASC' : 'DESC';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true" verbose="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>


### PR DESCRIPTION
## Summary
- use nullable string types for optional parameters
- update phpunit configuration schema to avoid deprecation warnings

## Testing
- `vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations`

------
https://chatgpt.com/codex/tasks/task_e_688098bf5dec832ab2882b245f88e67f