### PR TITLE
Add bindings test with cleanup

### DIFF
--- a/tests/ApplicationBindingsTest.php
+++ b/tests/ApplicationBindingsTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Core\Application;
+use FlujosDimension\Core\JWT;
+use FlujosDimension\Core\CacheManager;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationBindingsTest extends TestCase
+{
+    public function testJwtAndCacheBindings()
+    {
+        $app = new Application();
+        try {
+            $this->assertInstanceOf(JWT::class, $app->service(JWT::class));
+            $cacheDir = sys_get_temp_dir() . '/fd-cache';
+            $appCache = new CacheManager($cacheDir);
+            $this->assertInstanceOf(CacheManager::class, $appCache);
+            rmdir($cacheDir);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ApplicationBindingsTest` with `testJwtAndCacheBindings`
- ensure error/exception handlers are restored via `finally`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68809b093c48832ab8fdeb43b3edbfc8