### PR TITLE
Implement admin session auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,6 @@ OPENAI_API_KEY=your-openai-key
 PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_API_TOKEN=your-pipedrive-token
 JWT_SECRET=change-me
+ADMIN_USER=admin
+ADMIN_PASS=password
 

--- a/admin/api/batch_openai.php
+++ b/admin/api/batch_openai.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../auth.php';
+requireApiAuth();
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 $container = require dirname(__DIR__, 2) . '/app/bootstrap/container.php';
 

--- a/admin/api/generate_token.php
+++ b/admin/api/generate_token.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../auth.php';
+requireApiAuth();
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 $container = require dirname(__DIR__, 2) . '/app/bootstrap/container.php';
 

--- a/admin/api/push_pipedrive.php
+++ b/admin/api/push_pipedrive.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../auth.php';
+requireApiAuth();
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 $container = require dirname(__DIR__, 2) . '/app/bootstrap/container.php';
 

--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../auth.php';
+requireApiAuth();
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 $container = require dirname(__DIR__, 2) . '/app/bootstrap/container.php';
 

--- a/admin/auth.php
+++ b/admin/auth.php
@@ -1,0 +1,47 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function isAuthenticated(): bool {
+    return isset($_SESSION['authenticated']) && $_SESSION['authenticated'] === true;
+}
+
+function requireLogin(): void {
+    if (!isAuthenticated()) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+function csrfToken(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verifyCsrf(?string $token): bool {
+    return $token !== null && hash_equals($_SESSION['csrf_token'] ?? '', $token);
+}
+
+function requireApiAuth(): void {
+    if (!isAuthenticated()) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Authentication required']);
+        exit;
+    }
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $token = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+        if (!verifyCsrf($token)) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+            exit;
+        }
+    }
+}
+
+function logout(): void {
+    session_unset();
+    session_destroy();
+}

--- a/admin/index.php
+++ b/admin/index.php
@@ -8,6 +8,10 @@ define('ADMIN_ACCESS', true);
 error_reporting(E_ALL);
 ini_set('display_errors', 0);
 ini_set('log_errors', 1);
+require_once __DIR__ . '/auth.php';
+
+requireLogin();
+$csrf = csrfToken();
 /* ---------- Carga .env ---------- */
 $envFile = dirname(__DIR__) . '/.env';
 if (file_exists($envFile)) {
@@ -416,7 +420,12 @@ $apisStatus  = apiHealth();
     </style>
 </head>
 <body>
-<div class="header"><h1>🚀 Flujos Dimension v4.2.1</h1></div>
+<div class="header"><h1>🚀 Flujos Dimension v4.2.1</h1>
+    <div class="user-info">
+        <span>👤 <?=htmlspecialchars($_SESSION['admin_user'] ?? 'admin')?> </span>
+        <a href="logout.php" class="logout-btn">Cerrar Sesión</a>
+    </div>
+</div>
 <div class="container">
     <div class="tabs">
         <button class="tab-btn active" data-tab="dashboard">📞 Dashboard</button>
@@ -485,6 +494,7 @@ $apisStatus  = apiHealth();
 </div>
 
 <script>
+const csrfToken = '<?= $csrf ?>';
 /* --------- Navegación tabs --------- */
 document.querySelectorAll('.tab-btn').forEach(btn=>{
   btn.onclick=()=>{document.querySelectorAll('.tab-btn').forEach(b=>b.classList.remove('active'));
@@ -493,7 +503,12 @@ document.querySelectorAll('.tab-btn').forEach(btn=>{
 });
 
 /* --------- Helper ajax --------- */
-async function post(url,data){const r=await fetch(url,{method:'POST',body:data});return r.json();}
+async function post(url,data){
+  if(!(data instanceof FormData)) data = new FormData(data);
+  data.append('csrf_token', csrfToken);
+  const r=await fetch(url,{method:'POST',body:data});
+  return r.json();
+}
 
 /* --------- Generar token --------- */
 document.getElementById('btn-make-token').onclick=async()=>{

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_once dirname(__DIR__) . '/bootstrap/env.php';
+
+$error = '';
+
+if (isset($_GET['action']) && $_GET['action'] === 'login' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verifyCsrf($_POST['csrf_token'] ?? '')) {
+        $error = 'Token CSRF inválido';
+    } else {
+        $user = $_POST['username'] ?? '';
+        $pass = $_POST['password'] ?? '';
+        $envUser = $_ENV['ADMIN_USER'] ?? 'admin';
+        $envPass = $_ENV['ADMIN_PASS'] ?? 'password';
+        if ($user === $envUser && $pass === $envPass) {
+            $_SESSION['authenticated'] = true;
+            $_SESSION['admin_user'] = $user;
+            $_SESSION['login_time'] = time();
+            header('Location: index.php');
+            exit;
+        } else {
+            $error = 'Credenciales inválidas';
+        }
+    }
+}
+
+$csrf = csrfToken();
+include __DIR__ . '/views/login.php';

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/auth.php';
+logout();
+header('Location: login.php?logout=success');
+exit;

--- a/admin/views/login.php
+++ b/admin/views/login.php
@@ -171,6 +171,7 @@
         <?php endif; ?>
         
         <form method="POST" action="?action=login">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf ?? ''); ?>">
             <div class="form-group">
                 <label for="username">Usuario</label>
                 <input type="text" id="username" name="username" required autofocus>

--- a/bootstrap/env.php
+++ b/bootstrap/env.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+use Dotenv\Dotenv;
+
+$rootPath = dirname(__DIR__);
+$envFile  = $rootPath . '/.env';
+
+if (file_exists($envFile)) {
+    $dotenv = Dotenv::createImmutable($rootPath);
+    $dotenv->safeLoad();
+}


### PR DESCRIPTION
## Summary
- add simple session helper for admin login
- create login and logout scripts
- protect API endpoints with session and CSRF checks
- inject CSRF token into dashboard requests
- update example env with admin credentials
- load Dotenv config in admin login

## Testing
- `composer install`
- `vendor/bin/phpunit --colors=never`


------
https://chatgpt.com/codex/tasks/task_e_688032506e60832a9d1f47728584b0fa