### PR TITLE
Fix Dotenv loading for admin login

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/auth.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/bootstrap/env.php';
 $error = '';
 


### PR DESCRIPTION
## Summary
- ensure vendor classes autoload before reading environment for admin login

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880f1bc33c0832a81fe4486f2a25138