### PR TITLE
Add pipedrive_deal_id support in Call model

### DIFF
--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -311,6 +311,7 @@ class Database
                     ai_summary TEXT,
                     ai_sentiment ENUM('positive', 'negative', 'neutral') DEFAULT 'neutral',
                     pipedrive_contact_id INT,
+                    pipedrive_deal_id INT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                     INDEX idx_created_at (created_at),

--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -16,13 +16,14 @@ class Call extends BaseModel
     protected array $fillable = [
         'ringover_id', 'phone_number', 'direction', 'status', 'duration',
         'recording_url', 'ai_transcription', 'ai_summary', 'ai_sentiment',
-        'pipedrive_contact_id'
+        'pipedrive_contact_id', 'pipedrive_deal_id'
     ];
     
     protected array $casts = [
         'id' => 'int',
         'duration' => 'int',
         'pipedrive_contact_id' => 'int',
+        'pipedrive_deal_id' => 'int',
         'created_at' => 'datetime',
         'updated_at' => 'datetime'
     ];

--- a/tests/CallModelTest.php
+++ b/tests/CallModelTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Models\Call;
+use FlujosDimension\Core\Container;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class CallModelTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            "CREATE TABLE calls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ringover_id TEXT,
+                phone_number TEXT,
+                direction TEXT,
+                status TEXT,
+                duration INTEGER,
+                recording_url TEXT,
+                ai_transcription TEXT,
+                ai_summary TEXT,
+                ai_sentiment TEXT,
+                pipedrive_contact_id INTEGER,
+                pipedrive_deal_id INTEGER,
+                created_at TEXT,
+                updated_at TEXT
+            )"
+        );
+
+        $this->container = new Container();
+        $this->container->instance('database', $pdo);
+        $this->container->instance('logger', new class { public function info(...$a){} public function error(...$a){} });
+    }
+
+    public function testPersistPipedriveDealId(): void
+    {
+        $callModel = new Call($this->container);
+
+        $created = $callModel->create([
+            'ringover_id' => 'r1',
+            'phone_number' => '123456',
+            'direction' => 'inbound',
+            'status' => 'answered',
+            'duration' => 30,
+            'pipedrive_contact_id' => 11,
+            'pipedrive_deal_id' => 22
+        ]);
+
+        $this->assertSame(22, $created['pipedrive_deal_id']);
+        $this->assertIsInt($created['pipedrive_deal_id']);
+
+        $found = $callModel->find($created['id']);
+        $this->assertSame(22, $found['pipedrive_deal_id']);
+        $this->assertIsInt($found['pipedrive_deal_id']);
+    }
+}


### PR DESCRIPTION
## Summary
- persist `pipedrive_deal_id` in Call model
- include `pipedrive_deal_id` column when creating tables
- test Call model persistence of new field

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6889383b2694832ab1edad24d267ba9a