### PR TITLE
Fix composer autoload by removing unused helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,6 @@
     "psr-4": {
       "FlujosDimension\\": "app/"
     },
-    "files": [
-      "app/helpers.php"
-    ],
     "classmap": [
       "app/Core/Config.php",
       "app/Core/Database.php",


### PR DESCRIPTION
## Summary
- drop empty `helpers.php` file
- remove `app/helpers.php` from composer autoload

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6889f75710ac832a9945b4f916e48e0b