### PR TITLE
Merge container bootstrap into Application

### DIFF
--- a/app/bootstrap/container.php
+++ b/app/bootstrap/container.php
@@ -1,52 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use FlujosDimension\Core\Container;
-use FlujosDimension\Core\Config;
-use FlujosDimension\Core\Database;
-use FlujosDimension\Infrastructure\Http\HttpClient;
-use FlujosDimension\Repositories\CallRepository;
-use FlujosDimension\Services\{RingoverService, OpenAIService, PipedriveService, AnalyticsService};
+use FlujosDimension\Core\Application;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
-/* ---------- contenedor ---------- */
-$container = new Container();
-
-/* ---------- config & PDO ---------- */
-$cfg = Config::getInstance();
-$container->bind(Config::class, fn () => $cfg);
-$container->bind(PDO::class, fn () => Database::getInstance()->getConnection());
-
-
-/* ---------- HTTP ---------- */
-$container->singleton(HttpClient::class, fn () =>
-    new HttpClient(['headers' => ['User-Agent' => 'FlujosDimensionBot/1.0']])
-);
-$container->alias(HttpClient::class, 'httpClient');
-
-/* ---------- Repos ---------- */
-$container->singleton(CallRepository::class,
-    fn () => new CallRepository(Database::getInstance()->getConnection())
-);
-$container->alias(CallRepository::class, 'callRepository');
-
-/* ---------- Integraciones ---------- */
-$container->singleton(RingoverService::class,
-    fn ($c) => new RingoverService($c)
-);
-$container->singleton(OpenAIService::class,
-    fn ($c) => new OpenAIService($c->resolve('httpClient'), $cfg->get('OPENAI_API_KEY'))
-);
-$container->singleton(PipedriveService::class,
-    fn ($c) => new PipedriveService($c->resolve('httpClient'), $cfg->get('PIPEDRIVE_API_TOKEN'))
-);
-
-/* ---------- Dom / IA ---------- */
-$container->singleton(AnalyticsService::class,
-    fn ($c) => new AnalyticsService($c->resolve('callRepository'), $c->resolve(OpenAIService::class))
-);
-$container->alias(AnalyticsService::class, 'analyticsService');
-
-/* ---------- exporta ---------- */
-return $container;
+$app = new Application();
+return $app->getContainer();

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,3 +17,5 @@ Classes in `app/Repositories` implement focused data access layers using PDO. Th
 
 ## Admin scripts
 The `admin` directory provides a small web dashboard implemented with PHP scripts. These pages manage authentication, generate tokens, trigger synchronizations and render HTML views for configuration tasks.
+
+The admin utilities load a lightweight bootstrap file located at `app/bootstrap/container.php`. This script now creates an `Application` instance and exposes its service container so bindings stay identical to the main runtime.


### PR DESCRIPTION
## Summary
- integrate container bindings directly in `Application`
- expose container via `getContainer`
- replace old bootstrap container with an Application wrapper
- document the change in `docs/modules.md`

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --configuration phpunit.xml --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a3d19bba4832ab8ab9441163f49d1