### PR TITLE
Add phpdoc comments across project

### DIFF
--- a/app/Controllers/AnalysisController.php
+++ b/app/Controllers/AnalysisController.php
@@ -5,8 +5,14 @@ namespace FlujosDimension\Controllers;
 use FlujosDimension\Core\Response;
 use FlujosDimension\Services\AnalyticsService;
 
+/**
+ * Endpoints used to trigger and query AI analysis tasks.
+ */
 class AnalysisController extends BaseController
 {
+    /**
+     * Launch analysis batch processing.
+     */
     public function process(): Response
     {
         try {
@@ -28,6 +34,9 @@ class AnalysisController extends BaseController
         }
     }
 
+    /**
+     * Retrieve processing status for a given batch.
+     */
     public function batchStatus(string $id): Response
     {
         try {
@@ -46,6 +55,9 @@ class AnalysisController extends BaseController
         }
     }
 
+    /**
+     * Run a sentiment analysis batch on pending calls.
+     */
     public function sentimentBatch(): Response
     {
         try {
@@ -62,6 +74,9 @@ class AnalysisController extends BaseController
         }
     }
 
+    /**
+     * Return analysis keywords placeholder.
+     */
     public function keywords(): Response
     {
         try {

--- a/app/Controllers/ApiController.php
+++ b/app/Controllers/ApiController.php
@@ -6,8 +6,14 @@ use FlujosDimension\Core\Container;
 use FlujosDimension\Core\Request;
 use FlujosDimension\Core\Response;
 
+/**
+ * Simple endpoints to verify API health and status.
+ */
 class ApiController extends BaseController
 {
+    /**
+     * Return a short status payload for uptime checks.
+     */
     public function status(): Response
     {
         return $this->jsonResponse([
@@ -16,6 +22,9 @@ class ApiController extends BaseController
         ]);
     }
 
+    /**
+     * Basic health check used by monitoring services.
+     */
     public function health(): Response
     {
         return $this->jsonResponse([

--- a/app/Controllers/CallController.php
+++ b/app/Controllers/CallController.php
@@ -11,8 +11,14 @@ use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Example controller used in unit tests.
+ */
 final class CallController
 {
+    /**
+     * Inject required services.
+     */
     public function __construct(
         private readonly RingoverService   $ringover,
         private readonly AnalyticsService  $analytics,

--- a/app/Controllers/CallsController.php
+++ b/app/Controllers/CallsController.php
@@ -5,8 +5,14 @@ namespace FlujosDimension\Controllers;
 use FlujosDimension\Core\Response;
 use FlujosDimension\Models\Call;
 
+/**
+ * CRUD operations for call records stored in the system.
+ */
 class CallsController extends BaseController
 {
+    /**
+     * List calls with pagination metadata.
+     */
     public function index(): Response
     {
         try {
@@ -29,6 +35,9 @@ class CallsController extends BaseController
         }
     }
 
+    /**
+     * Display a single call record.
+     */
     public function show(string $id): Response
     {
         try {
@@ -45,6 +54,9 @@ class CallsController extends BaseController
         }
     }
 
+    /**
+     * Persist a new call entry.
+     */
     public function store(): Response
     {
         try {
@@ -69,6 +81,9 @@ class CallsController extends BaseController
         }
     }
 
+    /**
+     * Update an existing call.
+     */
     public function update(string $id): Response
     {
         try {
@@ -93,6 +108,9 @@ class CallsController extends BaseController
         }
     }
 
+    /**
+     * Delete a call record from storage.
+     */
     public function destroy(string $id): Response
     {
         try {

--- a/app/Controllers/ConfigController.php
+++ b/app/Controllers/ConfigController.php
@@ -5,8 +5,14 @@ namespace FlujosDimension\Controllers;
 use FlujosDimension\Core\Response;
 use FlujosDimension\Core\Config;
 
+/**
+ * Manage runtime configuration values.
+ */
 class ConfigController extends BaseController
 {
+    /**
+     * Return the full configuration array.
+     */
     public function index(): Response
     {
         try {
@@ -17,6 +23,9 @@ class ConfigController extends BaseController
         }
     }
 
+    /**
+     * Update a single configuration key.
+     */
     public function update(string $key): Response
     {
         try {
@@ -32,6 +41,9 @@ class ConfigController extends BaseController
         }
     }
 
+    /**
+     * Update multiple configuration values at once.
+     */
     public function batch(): Response
     {
         try {

--- a/app/Controllers/ReportController.php
+++ b/app/Controllers/ReportController.php
@@ -4,23 +4,38 @@ namespace FlujosDimension\Controllers;
 
 use FlujosDimension\Core\Response;
 
+/**
+ * Endpoints for report generation and download.
+ */
 class ReportController extends BaseController
 {
+    /**
+     * Kick off report creation.
+     */
     public function generate(): Response
     {
         return $this->jsonResponse(['success' => true, 'report_id' => 'report_1']);
     }
 
+    /**
+     * Check report generation status.
+     */
     public function status(string $id): Response
     {
         return $this->jsonResponse(['success' => true, 'report_id' => $id, 'status' => 'generating']);
     }
 
+    /**
+     * Provide a download link once ready.
+     */
     public function download(string $id): Response
     {
         return $this->jsonResponse(['success' => true, 'download' => $id]);
     }
 
+    /**
+     * Schedule periodic report generation.
+     */
     public function schedule(): Response
     {
         return $this->jsonResponse(['success' => true]);

--- a/app/Controllers/SyncController.php
+++ b/app/Controllers/SyncController.php
@@ -7,8 +7,14 @@ use FlujosDimension\Services\RingoverService;
 use FlujosDimension\Services\AnalyticsService;
 use FlujosDimension\Repositories\CallRepository;
 
+/**
+ * Synchronisation routines between Ringover and the local database.
+ */
 class SyncController extends BaseController
 {
+    /**
+     * Automatic hourly sync triggered by cron.
+     */
     public function hourly(): Response
     {
         try {
@@ -41,6 +47,9 @@ class SyncController extends BaseController
         }
     }
 
+    /**
+     * Manually start a sync for a custom time range.
+     */
     public function manual(): Response
     {
         try {
@@ -70,6 +79,9 @@ class SyncController extends BaseController
         }
     }
 
+    /**
+     * Return timestamp of the last synced call.
+     */
     public function status(): Response
     {
         try {

--- a/app/Controllers/TokenController.php
+++ b/app/Controllers/TokenController.php
@@ -5,8 +5,14 @@ namespace FlujosDimension\Controllers;
 use FlujosDimension\Core\Response;
 use FlujosDimension\Core\JWT;
 
+/**
+ * Issue and validate API tokens.
+ */
 class TokenController extends BaseController
 {
+    /**
+     * Generate a new API token for the caller.
+     */
     public function generate(): Response
     {
         try {
@@ -23,6 +29,9 @@ class TokenController extends BaseController
         }
     }
 
+    /**
+     * Check if a provided token is valid.
+     */
     public function verify(): Response
     {
         try {
@@ -43,6 +52,9 @@ class TokenController extends BaseController
         }
     }
 
+    /**
+     * Revoke a previously issued token.
+     */
     public function revoke(): Response
     {
         try {

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -5,8 +5,14 @@ namespace FlujosDimension\Controllers;
 use FlujosDimension\Core\Response;
 use PDO;
 
+/**
+ * Manage application users and their permissions.
+ */
 class UserController extends BaseController
 {
+    /**
+     * Return a list of active users.
+     */
     public function index(): Response
     {
         try {
@@ -23,6 +29,9 @@ class UserController extends BaseController
         }
     }
 
+    /**
+     * Create a new user in the system.
+     */
     public function create(): Response
     {
         try {
@@ -53,6 +62,9 @@ class UserController extends BaseController
         }
     }
 
+    /**
+     * Update an existing user's data.
+     */
     public function update(string $id): Response
     {
         try {
@@ -83,6 +95,9 @@ class UserController extends BaseController
         }
     }
 
+    /**
+     * Change the role or permissions of a user.
+     */
     public function permissions(string $id): Response
     {
         try {

--- a/app/Controllers/WebhookController.php
+++ b/app/Controllers/WebhookController.php
@@ -4,8 +4,14 @@ namespace FlujosDimension\Controllers;
 
 use FlujosDimension\Core\Response;
 
+/**
+ * Receive external webhook calls.
+ */
 class WebhookController extends BaseController
 {
+    /**
+     * Register a new webhook endpoint.
+     */
     public function create(): Response
     {
         return $this->jsonResponse(['success' => true, 'id' => 'webhook_1']);

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -23,6 +23,9 @@ abstract class BaseModel
     protected array $casts = [];
     protected bool $timestamps = true;
     
+    /**
+     * Resolve common services from the container.
+     */
     public function __construct(Container $container)
     {
         $this->container = $container;

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -5,10 +5,16 @@ namespace FlujosDimension\Services;
 
 use FlujosDimension\Repositories\CallRepository;
 
+/**
+ * Handles AI-based analysis of call records.
+ */
 final class AnalyticsService
 {
     private int $lastProcessed = 0;
 
+    /**
+     * Set up the repository and OpenAI client.
+     */
     public function __construct(
         private readonly CallRepository $repo,
         private readonly OpenAIService  $openai
@@ -40,6 +46,9 @@ final class AnalyticsService
         $this->lastProcessed = count($pending);
     }
 
+    /**
+     * Number of calls processed in the last batch.
+     */
     public function lastProcessed(): int
     {
         return $this->lastProcessed;

--- a/app/Services/OpenAIService.php
+++ b/app/Services/OpenAIService.php
@@ -6,10 +6,16 @@ namespace FlujosDimension\Services;
 use FlujosDimension\Infrastructure\Http\HttpClient;
 use RuntimeException;
 
+/**
+ * Lightweight wrapper for the OpenAI HTTP API.
+ */
 final class OpenAIService
 {
     private const BASE = 'https://api.openai.com/v1';
 
+    /**
+     * Configure the HTTP client, API key and model.
+     */
     public function __construct(
         private readonly HttpClient $http,
         private readonly string     $apiKey,

--- a/app/Services/PipedriveService.php
+++ b/app/Services/PipedriveService.php
@@ -6,15 +6,24 @@ namespace FlujosDimension\Services;
 use FlujosDimension\Infrastructure\Http\HttpClient;
 use RuntimeException;
 
+/**
+ * Simplified client for a subset of the Pipedrive API.
+ */
 final class PipedriveService
 {
     private const BASE = 'https://api.pipedrive.com/v1';
 
+    /**
+     * Provide HTTP client and API token.
+     */
     public function __construct(
         private readonly HttpClient $http,
         private readonly string     $token
     ) {}
 
+    /**
+     * Search a contact ID by phone number.
+     */
     public function findPersonByPhone(string $phone): ?int
     {
         $resp = $this->http->request('GET', self::BASE . '/persons/search', [
@@ -35,6 +44,11 @@ final class PipedriveService
     }
 
     /** @return int Deal-ID */
+    /**
+     * Create or update a Pipedrive deal.
+     *
+     * @return int Deal-ID
+     */
     public function createOrUpdateDeal(array $payload): int
     {
         $resp = $this->http->request('POST', self::BASE . '/deals', [

--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -17,6 +17,9 @@ class RingoverService
     private string     $apiKey;
     private string     $baseUrl;
 
+    /**
+     * Prepare HTTP client and configuration values.
+     */
     public function __construct(Container $c)
     {
         $this->http    = $c->resolve('httpClient');


### PR DESCRIPTION
## Summary
- document API controller endpoints
- add phpdocs for analysis endpoints
- document CRUD calls controller
- document config, report, sync and token controllers
- document user and webhook controllers
- update core models and services with phpdocs
- run `composer dump-autoload`

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688a5bac4f38832aa3d67ca9335d5a9c