### PR TITLE
Harden Ringover recording downloads

### DIFF
--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -82,7 +82,19 @@ class RingoverService
             throw new RuntimeException('Failed to download recording');
         }
 
-        $filename = $dir . '/' . basename(parse_url($url, PHP_URL_PATH));
+        $path     = parse_url($url, PHP_URL_PATH) ?: '';
+        $basename = basename($path);
+
+        // sanitize directory traversal characters
+        $basename = str_replace(['..', '/', '\\'], '', $basename);
+
+        $extension = strtolower(pathinfo($basename, PATHINFO_EXTENSION));
+        $allowed   = ['mp3', 'wav', 'ogg', 'm4a'];
+        if ($extension === '' || !in_array($extension, $allowed, true)) {
+            throw new RuntimeException('Invalid recording extension');
+        }
+
+        $filename = $dir . '/' . $basename;
         file_put_contents($filename, (string) $resp->getBody());
         return $filename;
     }

--- a/tests/RingoverServiceTest.php
+++ b/tests/RingoverServiceTest.php
@@ -51,4 +51,22 @@ class RingoverServiceTest extends TestCase
         unlink($path);
         rmdir($dir);
     }
+
+    public function testDownloadRecordingSanitizesPath()
+    {
+        $mock = new MockHandler([new Response(200, [], 'audio')]);
+        $stack = HandlerStack::create($mock);
+        $http = new HttpClient(['handler' => $stack]);
+        $container = new Container();
+        $container->instance('httpClient', $http);
+        $container->instance('config', ['RINGOVER_API_TOKEN' => 't']);
+        $service = new RingoverService($container);
+        $dir = sys_get_temp_dir().'/ringtest';
+        $malicious = 'https://files.test/..%2Fsecret/evil.mp3';
+        $path = $service->downloadRecording($malicious, $dir);
+        $this->assertStringStartsWith($dir, $path);
+        $this->assertFileExists($path);
+        unlink($path);
+        rmdir($dir);
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize filename for Ringover recordings
- add test that traversal characters do not escape download directory

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b1b408f08832abf1c9da6506a8d40