### PR TITLE
Improve admin API input validation

### DIFF
--- a/admin/api/batch_openai.php
+++ b/admin/api/batch_openai.php
@@ -8,9 +8,17 @@ use FlujosDimension\Services\AnalyticsService;
 /** @var AnalyticsService $ai */
 $ai = $container->resolve('analyticsService');
 
+$params = validate_input($request, [
+    'max' => ['filter' => FILTER_VALIDATE_INT]
+]);
+$max = $params['max'] ?? 50;
+if ($max <= 0) {
+    respond_error('Invalid max parameter');
+}
+
 $total = 0;
 do {
-    $ai->processBatch(50);
+    $ai->processBatch($max);
     $processed = $ai->lastProcessed();   // añade método que devuelva nº filas procesadas en la última tanda
     $total += $processed;
 } while ($processed > 0);

--- a/admin/api/push_pipedrive.php
+++ b/admin/api/push_pipedrive.php
@@ -10,8 +10,18 @@ use FlujosDimension\Repositories\CallRepository;
 $crm  = $container->resolve(PipedriveService::class);
 /** @var CallRepository $repo */
 $repo = $container->resolve('callRepository');
+$params = validate_input($request, [
+    'limit' => ['filter' => FILTER_VALIDATE_INT]
+]);
+$limit = $params['limit'] ?? null;
+if ($limit !== null && $limit <= 0) {
+    respond_error('Invalid limit parameter');
+}
 
 $pending = $repo->callsNotInCrm();   // SELECT * WHERE crm_synced=0
+if ($limit !== null) {
+    $pending = array_slice($pending, 0, $limit);
+}
 $created = 0;
 
 foreach ($pending as $c) {

--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -11,8 +11,18 @@ $ringover = $container->resolve(RingoverService::class);
 /** @var CallRepository $repo */
 $repo     = $container->resolve('callRepository');
 
-$since    = new DateTimeImmutable('-1 hour');
-$download = post_bool($request, 'download', false);
+$params   = validate_input($request, [
+    'download' => ['filter' => FILTER_VALIDATE_BOOLEAN],
+    'since'    => ['filter' => FILTER_SANITIZE_STRING]
+]);
+
+$download = $params['download'] ?? false;
+
+$sinceStr = $params['since'] ?? '-1 hour';
+$since    = @\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, (string)$sinceStr) ?: new \DateTimeImmutable((string)$sinceStr);
+if (!$since) {
+    respond_error('Invalid since parameter');
+}
 $inserted = 0;
 
 try {

--- a/tests/AdminApiTest.php
+++ b/tests/AdminApiTest.php
@@ -113,4 +113,25 @@ class AdminApiTest extends TestCase
         $this->assertTrue($r['data']['success']);
         $this->assertSame(5, $r['data']['processed']);
     }
+
+    public function testSyncRingoverInvalidDownload()
+    {
+        $r = $this->runScript('sync_ringover.php', ['download' => 'abc']);
+        $this->assertSame(400, $r['code']);
+        $this->assertFalse($r['data']['success']);
+    }
+
+    public function testBatchOpenaiInvalidMax()
+    {
+        $r = $this->runScript('batch_openai.php', ['max' => 'foo']);
+        $this->assertSame(400, $r['code']);
+        $this->assertFalse($r['data']['success']);
+    }
+
+    public function testPushPipedriveInvalidLimit()
+    {
+        $r = $this->runScript('push_pipedrive.php', ['limit' => '-1']);
+        $this->assertSame(400, $r['code']);
+        $this->assertFalse($r['data']['success']);
+    }
 }


### PR DESCRIPTION
## Summary
- add generic `validate_input` helper in admin API bootstrap
- validate POST parameters in sync, batch and push scripts
- cover invalid input scenarios with new AdminApiTest cases

## Testing
- `./vendor/bin/phpunit --stop-on-failure --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_688b1c437fa4832a8c508df54a1d238b