### PR TITLE
Add Ringover API connectivity check

### DIFF
--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -29,6 +29,23 @@ class RingoverService
     }
 
     /**
+     * Perform a lightweight request to verify API connectivity.
+     *
+     * @return array{success: bool}
+     */
+    public function testConnection(): array
+    {
+        try {
+            $resp = $this->http->request('HEAD', "{$this->baseUrl}/calls", [
+                'headers' => ['Authorization' => $this->apiKey],
+            ]);
+            return ['success' => $resp->getStatusCode() === 200];
+        } catch (\Throwable) {
+            return ['success' => false];
+        }
+    }
+
+    /**
      * Devuelve TODAS las llamadas creadas a partir de $since (UTC).  Generator → baja memoria.
      *
      * @return Generator<array<string,mixed>>


### PR DESCRIPTION
## Summary
- implement `RingoverService::testConnection()` using a HEAD request
- test success and failure for the new method
- use the service method from `DashboardController`

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b330bf6ac832a9ede0f76768ae4f1