### PR TITLE
Remove unused admin routes

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -259,15 +259,9 @@ private function registerServices(): void
             });
         });
         
-        // Admin Routes
-        $this->router->group('/admin', function($router) {
-            $router->get('/', 'AdminController@dashboard');
-            $router->get('/login', 'AdminController@login');
-            $router->post('/login', 'AdminController@authenticate');
-            $router->get('/logout', 'AdminController@logout');
-            $router->get('/env-editor', 'AdminController@envEditor');
-            $router->post('/env-save', 'AdminController@envSave');
-        });
+        // Admin routes are handled by standalone scripts in the `admin/`
+        // directory. Remove these entries until a dedicated controller is
+        // implemented.
     }
     
     /**


### PR DESCRIPTION
## Summary
- drop unused `/admin` route group from `Application::defineRoutes`
- admin utilities remain accessed via PHP scripts under `admin/`

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b34d61920832a8bf8941e05e3acdd