### PR TITLE
Implement dashboard data aggregation

### DIFF
--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -59,7 +59,27 @@ final class AnalyticsService
      */
     public function getDashboardData(string $period): array
     {
-        return ['success' => true, 'data' => []];
+        $now = new \DateTimeImmutable();
+
+        if (preg_match('/^(\d+)([dh])$/', $period, $m)) {
+            [$_, $num, $unit] = $m;
+            $interval = $unit === 'h' ? "PT{$num}H" : "P{$num}D";
+            $start = $now->sub(new \DateInterval($interval));
+        } else {
+            $start = $now->sub(new \DateInterval('P1D'));
+        }
+
+        $trends = $this->repo->callTrends($start, $now);
+        $summary = $this->repo->summary($start, $now);
+
+        return [
+            'success' => true,
+            'data' => [
+                'call_trends' => $trends,
+                'quick_stats' => $summary,
+                'last_updated' => $now->format('Y-m-d H:i:s'),
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
- implement `AnalyticsService::getDashboardData` to aggregate call info
- add `callTrends` and `summary` helpers to `CallRepository`
- test that dashboard index returns call data

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_688b372d1228832abfd618343b2550d7