### PR TITLE
Implement keywords endpoint and env validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,6 @@ PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_API_TOKEN=your-pipedrive-token
 JWT_SECRET=change-me
 ADMIN_USER=admin
-ADMIN_PASS=password
+# password_hash('password', PASSWORD_DEFAULT)
+ADMIN_PASS=$2y$12$96juvNB1AHHxmijQPKVz5.J9CrsDdgIYY9cA2LY.Qbv.4XxYBT.Cu
 

--- a/admin/login.php
+++ b/admin/login.php
@@ -11,8 +11,8 @@ if (isset($_GET['action']) && $_GET['action'] === 'login' && $_SERVER['REQUEST_M
         $user = $_POST['username'] ?? '';
         $pass = $_POST['password'] ?? '';
         $envUser = $_ENV['ADMIN_USER'] ?? 'admin';
-        $envPass = $_ENV['ADMIN_PASS'] ?? 'password';
-        if ($user === $envUser && $pass === $envPass) {
+        $envPassHash = $_ENV['ADMIN_PASS'] ?? password_hash('password', PASSWORD_DEFAULT);
+        if ($user === $envUser && password_verify($pass, $envPassHash)) {
             $_SESSION['authenticated'] = true;
             $_SESSION['admin_user'] = $user;
             $_SESSION['login_time'] = time();

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -52,6 +52,10 @@ class Application
             }
         }
 
+        if (!$this->config->validateRequiredConfig()) {
+            throw new \RuntimeException('Missing required configuration values');
+        }
+
         // Configurar zona horaria
         date_default_timezone_set($this->config->get('TIMEZONE'));
 

--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -237,15 +237,34 @@ class Call extends BaseModel
      */
     public function getTranscribedCalls(int $limit = 50): array
     {
-        $sql = "SELECT * FROM {$this->table} 
-                WHERE ai_transcription IS NOT NULL AND ai_transcription != '' 
-                ORDER BY created_at DESC 
+        $sql = "SELECT * FROM {$this->table}
+                WHERE ai_transcription IS NOT NULL AND ai_transcription != ''
+                ORDER BY created_at DESC
                 LIMIT :limit";
         
         $stmt = $this->database->prepare($sql);
         $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Calls that have transcription but missing keywords.
+     */
+    public function getCallsMissingKeywords(int $limit = 20): array
+    {
+        $sql = "SELECT * FROM {$this->table}
+                WHERE ai_transcription IS NOT NULL
+                  AND ai_transcription != ''
+                  AND (ai_keywords IS NULL OR ai_keywords = '')
+                ORDER BY created_at DESC
+                LIMIT :limit";
+
+        $stmt = $this->database->prepare($sql);
+        $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
         return $stmt->fetchAll();
     }
     

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,6 +11,7 @@ cp .env.example .env
    Edit `.env` and configure the database variables:
    `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`.
    Add your API tokens as needed.
+   The value of `ADMIN_PASS` should be generated with `password_hash`.
 3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server.
 4. **Launch the built-in PHP web server** for local testing.
    ```bash

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,4 +8,13 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="DB_HOST" value="localhost"/>
+        <env name="DB_NAME" value="testdb"/>
+        <env name="DB_USER" value="user"/>
+        <env name="DB_PASS" value="pass"/>
+        <env name="ADMIN_USER" value="admin"/>
+        <env name="ADMIN_PASS" value="secret"/>
+        <env name="JWT_SECRET" value="key"/>
+    </php>
 </phpunit>

--- a/tests/ControllerActionsTest.php
+++ b/tests/ControllerActionsTest.php
@@ -126,6 +126,15 @@ class ControllerActionsTest extends TestCase
         $this->assertSame(0, json_decode($res->getContent(), true)['processed']);
     }
 
+    public function testAnalysisKeywordsNoService()
+    {
+        $c = $this->container();
+        $controller = new AnalysisController($c, $this->request('GET','/api/analysis/keywords'));
+        $res = $controller->keywords();
+        $this->assertSame(200, $res->getStatusCode());
+        $this->assertSame([], json_decode($res->getContent(), true)['data']);
+    }
+
     public function testUserCreateWithoutDb()
     {
         $c = $this->container();


### PR DESCRIPTION
## Summary
- run config validation during app boot
- implement `/api/v3/analysis/keywords` using OpenAI
- add helper to fetch calls missing keywords
- hash admin password on login
- update install docs and example env
- configure phpunit env vars
- add regression test for keywords endpoint

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --display-errors`

------
https://chatgpt.com/codex/tasks/task_e_688b3fc0faa0832a9af6278f667236bb