### PR TITLE
Sanitize order_by inputs

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -175,11 +175,19 @@ abstract class BaseController
      */
     protected function getPaginationParams(): array
     {
+        $orderBy = $this->request->get('order_by', 'created_at');
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $orderBy)) {
+            $orderBy = 'created_at';
+        }
+
+        $direction = strtoupper($this->request->get('direction', 'DESC'));
+        $direction = $direction === 'ASC' ? 'ASC' : 'DESC';
+
         return [
             'page' => max(1, (int) $this->request->get('page', 1)),
             'per_page' => min(100, max(10, (int) $this->request->get('per_page', 20))),
-            'order_by' => $this->request->get('order_by', 'created_at'),
-            'direction' => strtoupper($this->request->get('direction', 'DESC'))
+            'order_by' => $orderBy,
+            'direction' => $direction
         ];
     }
     

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -21,6 +21,8 @@ abstract class BaseModel
     protected array $fillable = [];
     protected array $guarded = ['id', 'created_at', 'updated_at'];
     protected array $casts = [];
+    /** @var string[] Allowable columns for ORDER BY clauses */
+    protected array $sortable = [];
     protected bool $timestamps = true;
     
     /**
@@ -160,7 +162,12 @@ abstract class BaseModel
     public function paginate(int $page = 1, int $perPage = 20, ?string $orderBy = null, string $direction = 'DESC'): array
     {
         $orderBy = $orderBy ?: $this->primaryKey;
-        $direction = strtoupper($direction) === 'ASC' ? 'ASC' : 'DESC';
+        if (!empty($this->sortable) && !in_array($orderBy, $this->sortable, true)) {
+            $orderBy = $this->primaryKey;
+        }
+
+        $direction = strtoupper($direction);
+        $direction = $direction === 'ASC' ? 'ASC' : 'DESC';
         
         // Contar total
         $countSql = "SELECT COUNT(*) as total FROM {$this->table}";

--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -13,6 +13,10 @@ use Exception;
 class Call extends BaseModel
 {
     protected string $table = 'calls';
+    protected array $sortable = [
+        'id', 'created_at', 'updated_at', 'duration', 'status', 'direction',
+        'phone_number', 'ringover_id'
+    ];
     protected array $fillable = [
         'ringover_id', 'phone_number', 'direction', 'status', 'duration',
         'recording_url', 'ai_transcription', 'ai_summary', 'ai_keywords',
@@ -172,7 +176,12 @@ class Call extends BaseModel
         
         // Obtener datos paginados
         $orderBy = $filters['order_by'] ?? 'created_at';
+        if (!in_array($orderBy, $this->sortable, true)) {
+            $orderBy = 'created_at';
+        }
+
         $direction = strtoupper($filters['direction_sort'] ?? 'DESC');
+        $direction = $direction === 'ASC' ? 'ASC' : 'DESC';
         $offset = ($page - 1) * $perPage;
         
         $sql = "SELECT * FROM {$this->table} 

--- a/tests/Fixtures/PaginationController.php
+++ b/tests/Fixtures/PaginationController.php
@@ -1,0 +1,18 @@
+<?php
+namespace FlujosDimension\Controllers;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Core\Response;
+
+class PaginationController extends BaseController
+{
+    public function __construct(Container $c, Request $r)
+    {
+        parent::__construct($c, $r);
+    }
+
+    public function params(): array
+    {
+        return $this->getPaginationParams();
+    }
+}

--- a/tests/OrderBySanitizationTest.php
+++ b/tests/OrderBySanitizationTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Models\Call;
+use FlujosDimension\Controllers\PaginationController;
+use PDO;
+
+class OrderBySanitizationTest extends TestCase
+{
+    private Container $container;
+    private Call $model;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ringover_id TEXT,
+            phone_number TEXT,
+            direction TEXT,
+            status TEXT,
+            duration INTEGER,
+            recording_url TEXT,
+            ai_transcription TEXT,
+            ai_summary TEXT,
+            ai_keywords TEXT,
+            ai_sentiment TEXT,
+            pipedrive_contact_id INTEGER,
+            pipedrive_deal_id INTEGER,
+            created_at TEXT,
+            updated_at TEXT
+        )");
+        $pdo->exec("INSERT INTO calls (ringover_id, phone_number, direction, status, duration, created_at, updated_at) VALUES ('r1','111','inbound','answered',10,'2024-01-01 00:00:00','2024-01-01 00:00:00')");
+        $pdo->exec("INSERT INTO calls (ringover_id, phone_number, direction, status, duration, created_at, updated_at) VALUES ('r2','222','outbound','missed',20,'2024-01-02 00:00:00','2024-01-02 00:00:00')");
+
+        $this->container = new Container();
+        $this->container->instance('database', $pdo);
+        $this->container->instance('logger', new class { public function info(...$a){} public function error(...$a){} });
+        $this->model = new Call($this->container);
+    }
+
+    public function testPaginateRejectsInvalidOrderBy(): void
+    {
+        $result = $this->model->paginate(1, 10, 'duration; DROP TABLE calls', 'INVALID');
+        $this->assertCount(2, $result['data']);
+        $this->assertSame(2, $this->model->count());
+    }
+
+    public function testSearchRejectsOrderByInjection(): void
+    {
+        $result = $this->model->search(['order_by' => 'status; DROP', 'direction_sort' => 'DOWN']);
+        $this->assertCount(2, $result['data']);
+        $this->assertSame(2, $this->model->count());
+    }
+
+    public function testGetPaginationParamsSanitizesInput(): void
+    {
+        $this->container->instance('config', []);
+        $_GET = ['order_by' => 'id;DELETE', 'direction' => 'foo'];
+        $_POST = [];
+        $_SERVER = ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => '/'];
+        $request = new Request();
+        $controller = new PaginationController($this->container, $request);
+        $params = $controller->params();
+        $this->assertSame('created_at', $params['order_by']);
+        $this->assertSame('DESC', $params['direction']);
+    }
+}


### PR DESCRIPTION
## Summary
- restrict `getPaginationParams` to only accept alphanumeric order fields and normalize direction
- whitelist sortable columns on models
- sanitize order clauses in BaseModel and Call model search
- add controller fixture and unit tests for injection attempts

## Testing
- `composer install`
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b64d7ff44832ab2d7061f71fd5780