### PR TITLE
Implement active token listing endpoint

### DIFF
--- a/app/Controllers/TokenController.php
+++ b/app/Controllers/TokenController.php
@@ -72,4 +72,24 @@ class TokenController extends BaseController
             return $this->handleError($e, 'Error revoking token');
         }
     }
+
+    /**
+     * List currently active tokens.
+     */
+    public function active(): Response
+    {
+        try {
+            if (!$this->container->bound(JWT::class) && !$this->container->bound('jwtService')) {
+                return $this->successResponse([]);
+            }
+
+            /** @var JWT $jwt */
+            $jwt = $this->service('jwtService');
+            $tokens = $jwt->getActiveTokens();
+
+            return $this->successResponse($tokens);
+        } catch (\Exception $e) {
+            return $this->handleError($e, 'Error listing active tokens');
+        }
+    }
 }

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -262,6 +262,7 @@ private function registerServices(): void
                 $router->get('/sync/status', 'SyncController@status');
                 $router->post('/token/generate', 'TokenController@generate');
                 $router->post('/token/validate', 'TokenController@verify');
+                $router->get('/token/active', 'TokenController@active');
                 $router->delete('/token/revoke', 'TokenController@revoke');
             });
         });

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,9 @@ Generates a JWT token for API access.
 ### `POST /api/token/validate`
 Validates a token.
 
+### `GET /api/token/active`
+List active tokens issued by the system.
+
 ### `GET /api/calls`
 List calls. Parameters: `limit`, `offset`, `date`.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -153,6 +153,7 @@ Handles JSON Web Tokens for the API.
 - `generate()` issues a token.
 - `verify()` checks token validity.
 - `revoke()` invalidates a token.
+- `active()` lists active tokens.
 
 **Example**
 

--- a/tests/ApiEndpointTest.php
+++ b/tests/ApiEndpointTest.php
@@ -54,6 +54,29 @@ class ApiEndpointTest extends TestCase
         $this->assertTrue(json_decode($valResponse->getContent(), true)['valid']);
     }
 
+    public function testTokenActive()
+    {
+        $container = $this->makeContainer();
+        $container->instance('jwtService', new class {
+            public function getActiveTokens() {
+                return [[
+                    'id' => 1,
+                    'name' => 'demo',
+                    'expires_at' => '2030-01-01 00:00:00',
+                    'last_used_at' => null,
+                    'created_at' => '2024-01-01 00:00:00'
+                ]];
+            }
+        });
+        $controller = new TokenController($container, $this->makeRequest('GET', '/api/token/active'));
+        $response = $controller->active();
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertTrue($data['success']);
+        $this->assertIsArray($data['data']);
+        $this->assertArrayHasKey('id', $data['data'][0]);
+    }
+
     public function testSyncHourly()
     {
         $controller = new SyncController($this->makeContainer(), $this->makeRequest('POST', '/api/sync/hourly'));


### PR DESCRIPTION
## Summary
- list active tokens via `TokenController::active`
- expose new route `/token/active`
- document the new endpoint
- add test for listing active tokens

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688b84f05798832ab49b6b5684799368