### PR TITLE
Improve JSON parsing

### DIFF
--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -15,13 +15,13 @@ class Request
     private ?string $body;
     private ?array $jsonBody;
     
-    public function __construct()
+    public function __construct(?string $body = null)
     {
         $this->query = $_GET ?? [];
         $this->post = $_POST ?? [];
         $this->server = $_SERVER ?? [];
         $this->headers = $this->parseHeaders();
-        $this->body = file_get_contents('php://input');
+        $this->body = $body ?? file_get_contents('php://input');
         $this->jsonBody = null;
     }
     
@@ -72,8 +72,11 @@ class Request
     {
         if ($this->jsonBody === null && $this->body) {
             $this->jsonBody = json_decode($this->body, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \InvalidArgumentException('Invalid JSON body: ' . json_last_error_msg());
+            }
         }
-        
+
         return $this->jsonBody;
     }
     

--- a/tests/InvalidJsonTest.php
+++ b/tests/InvalidJsonTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Logger;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Controllers\ConfigController;
+
+class InvalidJsonTest extends TestCase
+{
+    private function container(): Container
+    {
+        $c = new Container();
+        $c->instance('logger', new Logger(sys_get_temp_dir()));
+        $c->instance('config', []);
+        return $c;
+    }
+
+    private function requestWithBody(string $method, string $uri, string $body): Request
+    {
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $uri,
+            'CONTENT_TYPE' => 'application/json',
+        ];
+        return new Request($body);
+    }
+
+    public function testInvalidJsonReturnsBadRequest()
+    {
+        $controller = new ConfigController(
+            $this->container(),
+            $this->requestWithBody('POST', '/api/config/batch', '{invalid}')
+        );
+        $response = $controller->batch();
+        $this->assertSame(400, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertFalse($data['success']);
+    }
+}


### PR DESCRIPTION
## Summary
- validate decoded JSON inside `Request::getJsonBody()` and raise `InvalidArgumentException` when invalid
- allow injecting the request body for tests
- add a unit test ensuring malformed JSON yields HTTP 400

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688b86a2f1b4832aa3598601473cf803