### PR TITLE
Add console command for hourly sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ cp .env.example .env
 php -S localhost:8000 -t public
 ```
 
+### Console usage
+
+An hourly synchronization task is available as a command line tool. Execute it
+via Composer's binary to import the latest calls:
+
+```bash
+vendor/bin/console sync:hourly
+```
+
 ### Admin login
 
 The admin panel located in the `admin/` directory requires session-based

--- a/app/Console/SyncHourlyCommand.php
+++ b/app/Console/SyncHourlyCommand.php
@@ -1,0 +1,71 @@
+<?php
+namespace FlujosDimension\Console;
+
+use FlujosDimension\Core\Application;
+use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Repositories\CallRepository;
+use FlujosDimension\Services\AnalyticsService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Console command to run hourly synchronization with Ringover.
+ */
+class SyncHourlyCommand extends Command
+{
+    protected static $defaultName = 'sync:hourly';
+    private Application $app;
+
+    public function __construct(?Application $app = null)
+    {
+        parent::__construct();
+        $this->app = $app ?? new Application();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Synchronize calls from Ringover (last hour).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $container = $this->app->getContainer();
+
+        try {
+            if (!$container->bound(RingoverService::class) || !$container->bound('callRepository')) {
+                $output->writeln('<info>No services configured</info>');
+                return Command::SUCCESS;
+            }
+
+            /** @var RingoverService $ringover */
+            $ringover = $container->resolve(RingoverService::class);
+            /** @var CallRepository $repo */
+            $repo     = $container->resolve('callRepository');
+            /** @var AnalyticsService|null $analytics */
+            $analytics = $container->bound('analyticsService') ? $container->resolve('analyticsService') : null;
+
+            $since = new \DateTimeImmutable('-1 hour');
+            $inserted = 0;
+            foreach ($ringover->getCalls($since) as $call) {
+                $repo->insertOrIgnore($call);
+                $inserted++;
+            }
+
+            if ($analytics) {
+                $analytics->processBatch();
+            }
+
+            $container->resolve('logger')->info('sync_hourly', ['inserted' => $inserted]);
+            $output->writeln("<info>Inserted: {$inserted}</info>");
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $container->resolve('logger')->error('Hourly sync failed', ['exception' => $e]);
+            $output->writeln('<error>'.$e->getMessage().'</error>');
+            return Command::FAILURE;
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+}

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Console\Application;
+use FlujosDimension\Console\SyncHourlyCommand;
+
+$application = new Application('FlujosDimension CLI');
+$application->add(new SyncHourlyCommand());
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^11.5"
-  }
+  },
+  "bin": ["bin/console"]
 }

--- a/tests/SyncHourlyCommandTest.php
+++ b/tests/SyncHourlyCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Console\SyncHourlyCommand;
+use FlujosDimension\Core\Application;
+use FlujosDimension\Core\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SyncHourlyCommandTest extends TestCase
+{
+    public function testCommandRunsWithoutServices(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->flush();
+        $container->instance('logger', new Logger(sys_get_temp_dir()));
+        $container->instance('config', []);
+
+        $command = new SyncHourlyCommand($app);
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        $this->assertSame(0, $status);
+        $this->assertStringContainsString('No services configured', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- add `SyncHourlyCommand` and CLI entry point
- register the console binary in Composer
- document command usage in README
- test command execution with `CommandTester`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688b882c25d4832a90290eff088015c3