### PR TITLE
Add token cleanup CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ via Composer's binary to import the latest calls:
 vendor/bin/console sync:hourly
 ```
 
+Expired tokens can also be purged with the cleanup command:
+
+```bash
+vendor/bin/console token:cleanup
+```
+
 ### Admin login
 
 The admin panel located in the `admin/` directory requires session-based

--- a/app/Console/TokenCleanupCommand.php
+++ b/app/Console/TokenCleanupCommand.php
@@ -1,0 +1,53 @@
+<?php
+namespace FlujosDimension\Console;
+
+use FlujosDimension\Core\Application;
+use FlujosDimension\Core\JWT;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Console command to remove expired JWT tokens from storage.
+ */
+class TokenCleanupCommand extends Command
+{
+    protected static $defaultName = 'token:cleanup';
+    private Application $app;
+
+    public function __construct(?Application $app = null)
+    {
+        parent::__construct();
+        $this->app = $app ?? new Application();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Delete expired or inactive API tokens.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $container = $this->app->getContainer();
+
+        try {
+            if (!$container->bound(JWT::class) && !$container->bound('jwtService')) {
+                $output->writeln('<info>No JWT service configured</info>');
+                return Command::SUCCESS;
+            }
+
+            /** @var JWT $jwt */
+            $jwt = $container->resolve(JWT::class);
+            $removed = $jwt->cleanupExpiredTokens();
+            $output->writeln("<info>Removed: {$removed}</info>");
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $container->resolve('logger')->error('token_cleanup_failed', ['exception' => $e]);
+            $output->writeln('<error>'.$e->getMessage().'</error>');
+            return Command::FAILURE;
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+}

--- a/bin/console
+++ b/bin/console
@@ -4,7 +4,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Symfony\Component\Console\Application;
 use FlujosDimension\Console\SyncHourlyCommand;
+use FlujosDimension\Console\TokenCleanupCommand;
 
 $application = new Application('FlujosDimension CLI');
 $application->add(new SyncHourlyCommand());
+$application->add(new TokenCleanupCommand());
 $application->run();

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -372,3 +372,15 @@ $repo->insertOrIgnore($call);
 The `admin` directory provides a small web dashboard implemented with PHP scripts. These pages manage authentication, generate tokens, trigger synchronizations and render HTML views for configuration tasks.
 
 The admin utilities load a lightweight bootstrap file located at `app/bootstrap/container.php`. This script now creates an `Application` instance and exposes its service container so bindings stay identical to the main runtime. Built-in admin routes were removed from the application kernel; all admin functionality lives in these scripts until a dedicated controller is introduced.
+
+## Console commands
+Two CLI tasks are included using the Symfony Console component:
+
+- `sync:hourly` imports the latest Ringover calls.
+- `token:cleanup` removes expired API tokens.
+
+Run them with:
+
+```bash
+vendor/bin/console <command>
+```

--- a/tests/TokenCleanupCommandTest.php
+++ b/tests/TokenCleanupCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Console\TokenCleanupCommand;
+use FlujosDimension\Core\Application;
+use FlujosDimension\Core\Logger;
+use FlujosDimension\Core\JWT;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class TokenCleanupCommandTest extends TestCase
+{
+    public function testCommandReportsRemovedCount(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->flush();
+        $container->instance('logger', new Logger(sys_get_temp_dir()));
+
+        $jwt = new class {
+            public function cleanupExpiredTokens() { return 5; }
+        };
+        $container->instance(JWT::class, $jwt);
+        $container->alias(JWT::class, 'jwtService');
+
+        $command = new TokenCleanupCommand($app);
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        $this->assertSame(0, $status);
+        $this->assertStringContainsString('Removed: 5', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- add `TokenCleanupCommand` for removing expired tokens
- register the command in the console bootstrap
- document usage in README and modules overview
- test new command with `CommandTester`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688ba5df2870832aa8ba0a501e3b8b69