### PR TITLE
docs: update console command docs and webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Expired tokens can also be purged with the cleanup command:
 vendor/bin/console token:cleanup
 ```
 
+See [console commands](docs/modules.md#console-commands) for more details.
+
+Webhook registration is documented in
+[docs/API.md#post-apiwebhooks](docs/API.md#post-apiwebhooks).
+
 ### Admin login
 
 The admin panel located in the `admin/` directory requires session-based

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,4 +39,15 @@ Trigger hourly synchronization from Ringover.
 ### `GET /api/sync/status`
 Get information about the last synchronization.
 
+### `POST /api/webhooks`
+Register an external webhook that will be notified on events.
+Parameters: `url`, `event`.
+
+Example request:
+```bash
+curl -X POST /api/webhooks \
+  -d "url=https://example.com/hook" \
+  -d "event=call.finished"
+```
+
 Additional routes exist for testing external APIs and for analytics endpoints as defined in the application.

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -24,3 +24,29 @@ Configura `ADMIN_USER` y `ADMIN_PASS` en tu archivo `.env` y accede a
 un token CSRF para las peticiones de la interfaz.
 
 Consulta [docs/INSTALL.md](INSTALL.md) para más detalles en inglés.
+
+### Comandos de consola
+
+Se incluyen dos tareas programadas a trav\u00e9s de Symfony Console:
+
+- `sync:hourly` importa las llamadas recientes de Ringover.
+- `token:cleanup` elimina los tokens expirados.
+
+Ejemplo de uso:
+
+```bash
+vendor/bin/console sync:hourly
+vendor/bin/console token:cleanup
+```
+
+### Endpoint de webhooks
+
+El API permite registrar webhooks externos mediante:
+
+`POST /api/webhooks`
+
+```bash
+curl -X POST https://localhost/api/webhooks \
+  -d "url=https://ejemplo.com/hook" \
+  -d "event=call.finished"
+```

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -241,7 +241,7 @@ POST /api/users
 ```
 
 ### WebhookController
-Placeholder for webhook registration.
+Handles registration of external webhooks.
 
 **Major methods**
 
@@ -250,7 +250,9 @@ Placeholder for webhook registration.
 **Example**
 
 ```bash
-POST /api/webhooks
+curl -X POST /api/webhooks \
+  -d "url=https://example.com/hook" \
+  -d "event=call.finished"
 ```
 
 ## Services
@@ -382,5 +384,6 @@ Two CLI tasks are included using the Symfony Console component:
 Run them with:
 
 ```bash
-vendor/bin/console <command>
+vendor/bin/console sync:hourly
+vendor/bin/console token:cleanup
 ```


### PR DESCRIPTION
## Summary
- document console commands in Spanish docs and module reference
- document the new `/api/webhooks` endpoint
- cross-link docs from README

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_688bae5779fc832aab75e4712dd90a66