### PR TITLE
Align api_tokens table with JWT implementation

### DIFF
--- a/database/flujodimen_db.sql
+++ b/database/flujodimen_db.sql
@@ -112,7 +112,7 @@ INSERT INTO `api_monitoring` (`id`, `api_name`, `endpoint`, `response_time`, `st
 
 CREATE TABLE `api_tokens` (
   `id` int(11) NOT NULL,
-  `token` varchar(255) NOT NULL,
+  `token_hash` varchar(255) NOT NULL,
   `name` varchar(100) DEFAULT NULL,
   `expires_at` timestamp NULL DEFAULT NULL,
   `last_used_at` timestamp NULL DEFAULT NULL,
@@ -788,8 +788,8 @@ ALTER TABLE `api_monitoring`
 --
 ALTER TABLE `api_tokens`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `token_hash` (`token`),
-  ADD KEY `idx_token_hash` (`token`),
+  ADD UNIQUE KEY `token_hash` (`token_hash`),
+  ADD KEY `idx_token_hash` (`token_hash`),
   ADD KEY `idx_expires_at` (`expires_at`);
 
 --

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,7 +12,8 @@ cp .env.example .env
    `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`.
    Add your API tokens as needed.
    The value of `ADMIN_PASS` should be generated with `password_hash`.
-3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server.
+3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server. The
+   `api_tokens` table now stores a `token_hash` column instead of the raw token.
 4. **Launch the built-in PHP web server** for local testing.
    ```bash
    php -S localhost:8000 -t public

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -14,7 +14,8 @@ Flujos Dimension sincroniza llamadas de Ringover y analiza las grabaciones con O
 1. Ejecuta `composer install` para descargar las dependencias.
 2. Copia `.env.example` a `.env` y configura `DB_HOST`, `DB_PORT`, `DB_NAME`,
    `DB_USER` y `DB_PASS`, además de tus tokens de API.
-3. Importa `database/flujodimen_db.sql` en tu servidor MySQL/MariaDB.
+3. Importa `database/flujodimen_db.sql` en tu servidor MySQL/MariaDB. La tabla
+   `api_tokens` ahora guarda el `token_hash` en lugar del token en texto claro.
 4. Inicia el servidor con `php -S localhost:8000 -t public`.
 
 ### Acceso al panel de administración


### PR DESCRIPTION
## Summary
- update `api_tokens` table definition to use `token_hash`
- update installation docs to mention hashed tokens

## Testing
- `composer install -n`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688c81820400832a97af0c1fa89f23cd