### PR TITLE
Configure OpenAI model via config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ RINGOVER_API_TOKEN=your-ringover-token
 RINGOVER_MAX_RECORDING_MB=100
 OPENAI_API_URL=https://api.openai.com/v1
 OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-4o-transcribe
 PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_API_TOKEN=your-pipedrive-token
 JWT_SECRET=change-me

--- a/app/Services/OpenAIService.php
+++ b/app/Services/OpenAIService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace FlujosDimension\Services;
 
 use FlujosDimension\Infrastructure\Http\HttpClient;
+use FlujosDimension\Core\Config;
 use RuntimeException;
 
 /**
@@ -12,15 +13,17 @@ use RuntimeException;
 final class OpenAIService
 {
     private const BASE = 'https://api.openai.com/v1';
+    private string $model;
 
     /**
-     * Configure the HTTP client, API key and model.
+     * Configure the HTTP client and API key.
      */
     public function __construct(
         private readonly HttpClient $http,
-        private readonly string     $apiKey,
-        private readonly string     $model = 'gpt-4o-mini'
-    ) {}
+        private readonly string     $apiKey
+    ) {
+        $this->model = Config::getInstance()->get('OPENAI_MODEL', 'gpt-4o-transcribe');
+    }
 
     /** @return array<string,mixed> */
     public function chat(array $messages, array $extra = []): array

--- a/tests/DashboardControllerTest.php
+++ b/tests/DashboardControllerTest.php
@@ -56,6 +56,7 @@ class DashboardControllerTest extends TestCase
         ]);
         $container->instance('logger', new DummyLogger());
         $container->instance('config', []);
+        \FlujosDimension\Core\Config::getInstance()->set('OPENAI_MODEL', 'model-x');
         $container->instance('database', $db);
         $pdo = new \PDO('sqlite::memory:');
         $repo = new CallRepository($pdo);
@@ -82,6 +83,7 @@ class DashboardControllerTest extends TestCase
         $container = new Container();
         $container->instance('logger', new DummyLogger());
         $container->instance('config', []);
+        \FlujosDimension\Core\Config::getInstance()->set('OPENAI_MODEL', 'model-x');
         $container->instance('database', new DummyDbForSystemInfo());
         $pdo = new \PDO('sqlite::memory:');
         $repo = new CallRepository($pdo);
@@ -108,6 +110,7 @@ class DashboardControllerTest extends TestCase
         $container = new Container();
         $container->instance('logger', new DummyLogger());
         $container->instance('config', []);
+        \FlujosDimension\Core\Config::getInstance()->set('OPENAI_MODEL', 'model-x');
         $container->instance('database', new DummyDbForSystemInfo());
 
         $pdo = new \PDO('sqlite::memory:');

--- a/tests/OpenAIServiceTest.php
+++ b/tests/OpenAIServiceTest.php
@@ -2,6 +2,7 @@
 namespace Tests;
 
 use FlujosDimension\Services\OpenAIService;
+use FlujosDimension\Core\Config;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
@@ -20,7 +21,8 @@ class OpenAIServiceTest extends TestCase
         $stack = HandlerStack::create($mock);
         $stack->push(Middleware::history($history));
         $http = new HttpClient(['handler' => $stack]);
-        $service = new OpenAIService($http, 'key', 'model-x');
+        Config::getInstance()->set('OPENAI_MODEL', 'model-x');
+        $service = new OpenAIService($http, 'key');
         $result = $service->chat([['role'=>'user','content'=>'hi']], ['temperature' => 0]);
         $this->assertSame('ok', $result['choices'][0]['message']['content']);
         $this->assertCount(1, $history);


### PR DESCRIPTION
## Summary
- add `OPENAI_MODEL` to environment example
- load model from config in `OpenAIService`
- provide model in tests using configuration container

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688c92e66dd0832a9870026a778e3199