### PR TITLE
refactor: inject config into RingoverService

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -163,7 +163,14 @@ private function registerServices(): void
     // Ringover
     $this->container->singleton(
         \FlujosDimension\Services\RingoverService::class,
-        fn ($c) => new \FlujosDimension\Services\RingoverService($c)   // usa Container internamente
+        fn ($c) => new \FlujosDimension\Services\RingoverService(
+            $c->resolve('httpClient'),
+            $this->config
+        )
+    );
+    $this->container->alias(
+        \FlujosDimension\Services\RingoverService::class,
+        'ringoverService'
     );
 
     /* ---------- Servicios de dominio ---------- */

--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace FlujosDimension\Services;
 
-use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Config;
 use FlujosDimension\Infrastructure\Http\HttpClient;
 use Generator;
 use RuntimeException;
@@ -21,13 +21,12 @@ class RingoverService
     /**
      * Prepare HTTP client and configuration values.
      */
-    public function __construct(Container $c)
+    public function __construct(HttpClient $http, Config $config)
     {
-        $this->http    = $c->resolve('httpClient');
-        $config        = $c->resolve('config');
-        $this->apiKey  = $config['RINGOVER_API_TOKEN'] ?? '';
-        $this->baseUrl = $config['RINGOVER_API_URL']  ?? 'https://public-api.ringover.com/v2';
-        $limitMb       = (int)($config['RINGOVER_MAX_RECORDING_MB'] ?? 100);
+        $this->http    = $http;
+        $this->apiKey  = $config->get('RINGOVER_API_TOKEN', '');
+        $this->baseUrl = $config->get('RINGOVER_API_URL', 'https://public-api.ringover.com/v2');
+        $limitMb       = (int)$config->get('RINGOVER_MAX_RECORDING_MB', 100);
         $this->maxSize = $limitMb * 1024 * 1024;
     }
 


### PR DESCRIPTION
## Summary
- refactor RingoverService to receive HttpClient and Config objects
- expose RingoverService through container using direct dependencies and alias
- update RingoverService tests for new constructor

## Testing
- `vendor/bin/phpunit`
- `php -r 'require "vendor/autoload.php"; session_start(); $_SESSION["authenticated"]=true; $_SESSION["csrf_token"]="tok"; $_POST=["download"=>"1","csrf_token"=>"tok"]; $_SERVER["REQUEST_METHOD"]="POST"; $_SERVER["REQUEST_URI"]="/admin/api/sync_ringover.php"; $container=new \\FlujosDimension\\Core\\Container(); $container->instance(\\FlujosDimension\\Services\\RingoverService::class,new class { public function getCalls($since){return [];} public function downloadRecording($url){} }); $container->alias(\\FlujosDimension\\Services\\RingoverService::class,"ringoverService"); $container->instance("callRepository",new class { public function insertOrIgnore($call){} }); define("FD_TESTING",true); include "admin/api/sync_ringover.php";'`

------
https://chatgpt.com/codex/tasks/task_e_68934fa0acbc832a81ef46e5eff602d1