### PR TITLE
Fix sanitization for Ringover sync since parameter

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -13,13 +13,14 @@ $repo     = $container->resolve('callRepository');
 
 $params   = validate_input($request, [
     'download' => ['filter' => FILTER_VALIDATE_BOOLEAN],
-    'since'    => ['filter' => FILTER_SANITIZE_STRING]
+    // FILTER_SANITIZE_STRING is deprecated; use a permitted filter and sanitize manually
+    'since'    => ['filter' => FILTER_UNSAFE_RAW]
 ]);
 
 $download = $params['download'] ?? false;
 
-$sinceStr = $params['since'] ?? '-1 hour';
-$since    = @\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, (string)$sinceStr) ?: new \DateTimeImmutable((string)$sinceStr);
+$sinceStr = sanitize_string((string)($params['since'] ?? '-1 hour'));
+$since    = @\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $sinceStr) ?: new \DateTimeImmutable($sinceStr);
 if (!$since) {
     respond_error('Invalid since parameter');
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW`
- Sanitize `since` parameter manually before parsing

## Testing
- `vendor/bin/phpunit`
- `php admin/api/sync_ringover.php` (returns authentication error, verifying script runs)


------
https://chatgpt.com/codex/tasks/task_e_68935c7636cc832abb30a7fa69f9f7ff