### PR TITLE
feat: add configurable log level

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -5,17 +5,31 @@ require __DIR__ . '/init.php';
 
 use FlujosDimension\Services\RingoverService;
 use FlujosDimension\Repositories\CallRepository;
+use FlujosDimension\Core\Request;
 
 // Configuración de niveles de log
 define('LOG_LEVEL_DEBUG', 0);
 define('LOG_LEVEL_INFO', 1);
 define('LOG_LEVEL_ERROR', 2);
 
-// Cambia este valor para ajustar el nivel de detalle del log
-$GLOBALS['CURRENT_LOG_LEVEL'] = LOG_LEVEL_DEBUG;
-
 // Inicializa el log
 $GLOBALS['logFile'] = __DIR__ . '/sync_ringover.log';
+
+if (!function_exists('determine_log_level')) {
+    function determine_log_level(Request $request): int {
+        $value = $request->get('log_level') ?? $request->post('log_level') ?? getenv('RINGOVER_LOG_LEVEL');
+        $value = $value ? strtoupper((string) $value) : '';
+        $map = [
+            'DEBUG' => LOG_LEVEL_DEBUG,
+            'INFO'  => LOG_LEVEL_INFO,
+            'ERROR' => LOG_LEVEL_ERROR,
+        ];
+        return $map[$value] ?? LOG_LEVEL_DEBUG;
+    }
+}
+
+$GLOBALS['CURRENT_LOG_LEVEL'] = determine_log_level($request);
+
 if (!function_exists('writeLog')) {
     function writeLog($level, $message, $data = null) {
         if ($level < $GLOBALS['CURRENT_LOG_LEVEL']) return;
@@ -44,7 +58,9 @@ if (!function_exists('parseSince')) {
     }
 }
 
-writeLog(LOG_LEVEL_INFO, 'Starting Ringover sync process');
+writeLog(LOG_LEVEL_INFO, 'Starting Ringover sync process', [
+    'log_level' => ['DEBUG','INFO','ERROR'][$GLOBALS['CURRENT_LOG_LEVEL']],
+]);
 
 // Inicializa servicios y registra en el log
 /** @var RingoverService $ringover */


### PR DESCRIPTION
## Summary
- allow overriding Ringover sync log level via request or environment
- log the active level on start

## Testing
- `php -l admin/api/sync_ringover.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68936cd062f0832a9952e6a4221c0151