### PR TITLE
Ensure Ringover sync logs to storage directory

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -13,7 +13,11 @@ define('LOG_LEVEL_INFO', 1);
 define('LOG_LEVEL_ERROR', 2);
 
 // Inicializa el log
-$GLOBALS['logFile'] = __DIR__ . '/sync_ringover.log';
+$logDir = dirname(__DIR__, 2) . '/storage/logs';
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0755, true);
+}
+$GLOBALS['logFile'] = $logDir . '/sync_ringover.log';
 
 if (!function_exists('determine_log_level')) {
     function determine_log_level(Request $request): int {


### PR DESCRIPTION
## Summary
- initialize sync_ringover log file in storage/logs and create directory if needed

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6893929a07f4832a82522ef32eb6fae4