### PR TITLE
Add Ringover call field mapper and idempotent persistence

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -100,10 +100,11 @@ try {
 
         $retrieved++;
         writeLog(LOG_LEVEL_DEBUG, 'Processing call', $call);
-        $result = $repo->insertOrIgnore($call);
-        if ($download && !empty($call['recording_url'])) {
-            writeLog(LOG_LEVEL_INFO, 'Downloading recording', ['url' => $call['recording_url']]);
-            $ringoverService->downloadRecording($call['recording_url']);
+        $mapped = $ringoverService->mapCallFields($call);
+        $result = $repo->insertOrIgnore($mapped);
+        if ($download && !empty($mapped['recording_url'])) {
+            writeLog(LOG_LEVEL_INFO, 'Downloading recording', ['url' => $mapped['recording_url']]);
+            $ringoverService->downloadRecording($mapped['recording_url']);
         }
         if ($result > 0) {
             $inserted++;

--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -59,7 +59,7 @@ final class CallRepository
         $this->db->commit();
     }
 
-    /** Insert a call if ringover_id not present
+    /** Insert a call using mapped keys. Ignores duplicates by ringover_id.
      *  @return int Number of rows inserted (0 if ignored)
      */
     public function insertOrIgnore(array $call): int
@@ -69,7 +69,7 @@ final class CallRepository
 
         $stmt = $this->db->prepare($sql);
         $stmt->execute([
-            ':ringover_id'  => $call['id']          ?? null,
+            ':ringover_id'  => $call['ringover_id']  ?? null,
             ':phone_number' => $call['phone_number'] ?? null,
             ':direction'    => $call['direction']    ?? 'inbound',
             ':status'       => $call['status']       ?? 'pending',

--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -134,6 +134,25 @@ class RingoverService
     }
 
     /**
+     * Map raw Ringover call data to internal call fields.
+     *
+     * @param array<string,mixed> $call
+     * @return array<string,mixed>
+     */
+    public function mapCallFields(array $call): array
+    {
+        return [
+            'ringover_id'  => $call['id']             ?? null,
+            'phone_number' => $call['contact_number'] ?? ($call['from_number'] ?? ($call['to_number'] ?? null)),
+            'direction'    => $call['direction']      ?? ($call['type'] ?? null),
+            'status'       => $call['status']         ?? ($call['last_state'] ?? null),
+            'duration'     => $call['duration']       ?? ($call['total_duration'] ?? 0),
+            'recording_url'=> $call['recording_url']  ?? ($call['recording'] ?? null),
+            'start_time'   => $call['start_time']     ?? ($call['started_at'] ?? null),
+        ];
+    }
+
+    /**
      * Download a recording URL into storage/recordings.
      * @return string Local path
      */

--- a/tests/AdminApiTest.php
+++ b/tests/AdminApiTest.php
@@ -36,8 +36,9 @@ class AdminApiTest extends TestCase
         $this->container->alias(PipedriveService::class, 'pipedriveService');
 
         $this->container->instance(RingoverService::class, new class {
-            public function getCalls($since){ return [['recording_url'=>null]]; }
+            public function getCalls($since){ return [['ringover_id' => 'r1', 'recording_url'=>null]]; }
             public function downloadRecording($url){}
+            public function mapCallFields($call){ return $call; }
         });
         $this->container->alias(RingoverService::class, 'ringoverService');
 


### PR DESCRIPTION
## Summary
- map Ringover call payloads to internal call fields
- persist mapped calls in sync script and download recordings from mapped data
- store calls using mapped keys and ignore duplicates by `ringover_id`

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895b3a60bfc832a95c920a887f6a491