### PR TITLE
Add Ringover webhook handlers for recordings and voicemails

### DIFF
--- a/app/Controllers/RingoverWebhookController.php
+++ b/app/Controllers/RingoverWebhookController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace FlujosDimension\Controllers;
+
+use FlujosDimension\Core\Response;
+use FlujosDimension\Services\RingoverService;
+use PDO;
+
+/**
+ * Handle Ringover webhook callbacks.
+ */
+class RingoverWebhookController extends BaseController
+{
+    /**
+     * Recording available webhook.
+     */
+    public function recordAvailable(): Response
+    {
+        try {
+            if (!$this->isValidSignature()) {
+                return $this->errorResponse('Invalid signature', 401);
+            }
+
+            $data = $this->request->getJsonBody() ?? [];
+            $this->validate($data, [
+                'call_id' => 'required|string',
+                'recording_url' => 'required|string',
+            ]);
+
+            /** @var RingoverService $ringover */
+            $ringover = $this->service(RingoverService::class);
+            $localPath = $ringover->downloadRecording($data['recording_url'], 'storage/recordings');
+
+            $this->storeRecording($data['call_id'], $data['recording_url'], $localPath, $data['duration'] ?? 0);
+
+            return $this->successResponse(['stored' => true]);
+        } catch (\Exception $e) {
+            return $this->handleError($e, 'Error processing recording webhook');
+        }
+    }
+
+    /**
+     * Voicemail available webhook.
+     */
+    public function voicemailAvailable(): Response
+    {
+        try {
+            if (!$this->isValidSignature()) {
+                return $this->errorResponse('Invalid signature', 401);
+            }
+
+            $data = $this->request->getJsonBody() ?? [];
+            $this->validate($data, [
+                'call_id' => 'required|string',
+                'voicemail_url' => 'required|string',
+            ]);
+
+            /** @var RingoverService $ringover */
+            $ringover = $this->service(RingoverService::class);
+            $localPath = $ringover->downloadRecording($data['voicemail_url'], 'storage/voicemails');
+
+            $this->storeRecording($data['call_id'], $data['voicemail_url'], $localPath, $data['duration'] ?? 0);
+
+            return $this->successResponse(['stored' => true]);
+        } catch (\Exception $e) {
+            return $this->handleError($e, 'Error processing voicemail webhook');
+        }
+    }
+
+    /**
+     * Validate webhook signature using configured secret.
+     */
+    private function isValidSignature(): bool
+    {
+        $secret = $this->config('RINGOVER_WEBHOOK_SECRET');
+        $signature = $this->request->getHeader('x-ringover-signature');
+        $payload = $this->request->getBody() ?? '';
+
+        if (!$secret || !$signature) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $payload, $secret);
+        return hash_equals($expected, $signature);
+    }
+
+    /**
+     * Persist recording metadata for the given call.
+     */
+    private function storeRecording(string $ringoverId, string $url, string $path, int $duration): void
+    {
+        /** @var PDO $pdo */
+        $pdo = $this->service('database');
+
+        $pdo->beginTransaction();
+
+        // Update calls table
+        $stmt = $pdo->prepare('UPDATE calls SET recording_url = :url, recording_path = :path, has_recording = 1 WHERE ringover_id = :ringover_id');
+        $stmt->execute([
+            'url' => $url,
+            'path' => $path,
+            'ringover_id' => $ringoverId,
+        ]);
+
+        // Get internal call id
+        $idStmt = $pdo->prepare('SELECT id FROM calls WHERE ringover_id = :ringover_id');
+        $idStmt->execute(['ringover_id' => $ringoverId]);
+        $callId = $idStmt->fetchColumn();
+
+        if ($callId) {
+            $size = filesize($path) ?: 0;
+            $format = pathinfo($path, PATHINFO_EXTENSION) ?: 'mp3';
+            $insert = $pdo->prepare('INSERT INTO call_recordings (call_id, file_path, file_size, duration, format) VALUES (:call_id, :file_path, :file_size, :duration, :format)');
+            $insert->execute([
+                'call_id' => $callId,
+                'file_path' => $path,
+                'file_size' => $size,
+                'duration' => $duration,
+                'format' => $format,
+            ]);
+        }
+
+        $pdo->commit();
+    }
+}

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -275,6 +275,10 @@ private function registerServices(): void
                 // Webhooks
                 $router->post('/webhooks', 'WebhookController@create');
 
+                // Ringover specific webhooks
+                $router->post('/webhooks/ringover/record-available', 'RingoverWebhookController@recordAvailable');
+                $router->post('/webhooks/ringover/voicemail-available', 'RingoverWebhookController@voicemailAvailable');
+
                 // Sync and token
                 $router->post('/sync/hourly', 'SyncController@hourly');
                 $router->post('/sync/manual', 'SyncController@manual');

--- a/tests/RingoverWebhookControllerTest.php
+++ b/tests/RingoverWebhookControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Core\Container;
+use FlujosDimension\Core\Request;
+use FlujosDimension\Controllers\RingoverWebhookController;
+use FlujosDimension\Services\RingoverService;
+use PDO;
+
+class RingoverWebhookControllerTest extends TestCase
+{
+    private function container(PDO $pdo, string $secret): Container
+    {
+        $c = new Container();
+        $c->instance('logger', new class { public function error(...$a){} public function info(...$a){} });
+        $c->instance('config', ['RINGOVER_WEBHOOK_SECRET' => $secret]);
+        $c->instance('database', $pdo);
+        return $c;
+    }
+
+    private function request(string $method, string $uri, string $body, string $signature): Request
+    {
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $uri,
+            'HTTP_X_RINGOVER_SIGNATURE' => $signature,
+        ];
+        return new Request($body);
+    }
+
+    public function testRecordAvailableStoresMetadata(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE calls (id INTEGER PRIMARY KEY AUTOINCREMENT, ringover_id TEXT, recording_url TEXT, recording_path TEXT, has_recording INTEGER DEFAULT 0);");
+        $pdo->exec("CREATE TABLE call_recordings (id INTEGER PRIMARY KEY AUTOINCREMENT, call_id INTEGER, file_path TEXT, file_size INTEGER, duration INTEGER, format TEXT);");
+        $pdo->exec("INSERT INTO calls (ringover_id) VALUES ('r1')");
+
+        $secret = 'topsecret';
+        $body = json_encode(['call_id' => 'r1', 'recording_url' => 'http://example.com/a.mp3', 'duration' => 5]);
+        $sig = hash_hmac('sha256', $body, $secret);
+
+        $c = $this->container($pdo, $secret);
+        $c->instance(RingoverService::class, new class extends RingoverService {
+            public function __construct(){}
+            public function downloadRecording(string $url, string $dir = 'storage/recordings'): string
+            {
+                if (!is_dir($dir)) { mkdir($dir, 0755, true); }
+                $path = $dir . '/test.mp3';
+                file_put_contents($path, 'data');
+                return $path;
+            }
+        });
+
+        $controller = new RingoverWebhookController($c, $this->request('POST', '/api/v3/webhooks/ringover/record-available', $body, $sig));
+        $resp = $controller->recordAvailable();
+        $this->assertSame(200, $resp->getStatusCode());
+        $data = json_decode($resp->getContent(), true);
+        $this->assertTrue($data['success']);
+
+        $call = $pdo->query("SELECT recording_url, recording_path, has_recording FROM calls WHERE ringover_id='r1'")->fetch();
+        $this->assertSame('http://example.com/a.mp3', $call['recording_url']);
+        $this->assertNotEmpty($call['recording_path']);
+        $this->assertSame(1, (int)$call['has_recording']);
+
+        $count = $pdo->query('SELECT COUNT(*) FROM call_recordings')->fetchColumn();
+        $this->assertSame(1, (int)$count);
+    }
+
+    public function testInvalidSignatureRejected(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE calls (id INTEGER PRIMARY KEY AUTOINCREMENT, ringover_id TEXT);");
+        $pdo->exec("CREATE TABLE call_recordings (id INTEGER PRIMARY KEY AUTOINCREMENT, call_id INTEGER, file_path TEXT, file_size INTEGER, duration INTEGER, format TEXT);");
+
+        $secret = 'abc';
+        $body = json_encode(['call_id' => 'r1', 'recording_url' => 'http://e/a.mp3']);
+        $sig = 'bad';
+
+        $c = $this->container($pdo, $secret);
+        $controller = new RingoverWebhookController($c, $this->request('POST', '/api/v3/webhooks/ringover/record-available', $body, $sig));
+        $resp = $controller->recordAvailable();
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- Add RingoverWebhookController with endpoints for recording and voicemail callbacks
- Validate webhook signatures and download media to storage
- Update call metadata and log recordings
- Register new webhook routes and add unit tests

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6895b5493990832a889a26c5e7b5b076