### PR TITLE
Add Ringover webhook configuration and integration test scripts

### DIFF
--- a/admin/api/configure_webhooks.php
+++ b/admin/api/configure_webhooks.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/init.php';
+
+use FlujosDimension\Infrastructure\Http\HttpClient;
+use FlujosDimension\Core\Config;
+
+/** @var Config $config */
+$config = $container->resolve(Config::class);
+/** @var HttpClient $http */
+$http   = $container->resolve(HttpClient::class);
+
+$baseUrl   = rtrim((string)$config->get('RINGOVER_API_URL', 'https://public-api.ringover.com/v2'), '/');
+$apiKey    = (string)$config->get('RINGOVER_API_TOKEN', '');
+$appUrl    = rtrim((string)$config->get('APP_URL', 'https://example.com'), '/');
+$webhookBase = $appUrl . '/api/v3/webhooks/ringover';
+
+$events = [
+    ['event' => 'recording.available', 'path' => '/record-available'],
+    ['event' => 'voicemail.available', 'path' => '/voicemail-available'],
+];
+
+try {
+    foreach ($events as $e) {
+        $resp = $http->request('POST', "$baseUrl/webhooks", [
+            'headers' => ['Authorization' => $apiKey],
+            'json' => [
+                'event' => $e['event'],
+                'url'   => $webhookBase . $e['path'],
+            ],
+        ]);
+
+        $status = $resp->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw new RuntimeException('Unexpected status ' . $status);
+        }
+    }
+
+    echo json_encode(['success' => true, 'message' => 'Webhooks configured']);
+} catch (Throwable $e) {
+    $steps = [
+        '1. Sign in to Ringover dashboard.',
+        "2. Create webhook for \"recording.available\" pointing to {$webhookBase}/record-available.",
+        "3. Create webhook for \"voicemail.available\" pointing to {$webhookBase}/voicemail-available.",
+        '4. Ensure the signing secret matches RINGOVER_WEBHOOK_SECRET in your environment.',
+    ];
+    echo json_encode([
+        'success' => false,
+        'message' => 'Automatic webhook setup failed or not supported. Configure manually.',
+        'manual_steps' => $steps,
+    ], JSON_PRETTY_PRINT);
+}
+
+exit(0);

--- a/admin/api/test_ringover_integration.php
+++ b/admin/api/test_ringover_integration.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/init.php';
+
+use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Repositories\CallRepository;
+
+$logDir = dirname(__DIR__, 2) . '/storage/logs';
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0755, true);
+}
+$logFile = $logDir . '/integration_test.log';
+
+function log_line(string $message): void {
+    global $logFile;
+    $ts = date('Y-m-d H:i:s');
+    file_put_contents($logFile, "[{$ts}] {$message}\n", FILE_APPEND);
+}
+
+try {
+    /** @var RingoverService $ringover */
+    $ringover = $container->resolve(RingoverService::class);
+    /** @var CallRepository $repo */
+    $repo     = $container->resolve('callRepository');
+
+    $params = validate_input($request, [
+        'start_date' => ['filter' => FILTER_UNSAFE_RAW, 'required' => true],
+    ]);
+
+    try {
+        $start = new DateTimeImmutable((string)$params['start_date']);
+    } catch (Throwable $e) {
+        log_line('Invalid start_date: ' . $e->getMessage());
+        echo json_encode(['success' => false, 'message' => 'Invalid start_date']);
+        exit(1);
+    }
+
+    log_line('Starting integration test at ' . $start->format(DATE_ATOM));
+
+    $auth = $ringover->testConnection();
+    if (!($auth['success'] ?? false)) {
+        log_line('Ringover authentication failed');
+        echo json_encode(['success' => false, 'message' => 'Ringover authentication failed']);
+        exit(1);
+    }
+    log_line('Authentication successful');
+
+    $calls = iterator_to_array($ringover->getCalls($start));
+    $count = count($calls);
+    log_line('Calls retrieved: ' . $count);
+    if ($count === 0) {
+        echo json_encode(['success' => false, 'message' => 'No calls returned']);
+        exit(1);
+    }
+
+    $sample = $calls[0];
+    $mapped = $ringover->mapCallFields($sample);
+    $inserted = $repo->insertOrIgnore($mapped);
+    if ($inserted === 0) {
+        log_line('Database insert failed');
+        echo json_encode(['success' => false, 'message' => 'Database insert failed']);
+        exit(1);
+    }
+    log_line('Database write ok');
+
+    if (empty($mapped['recording_url'])) {
+        log_line('No recording URL available');
+        echo json_encode(['success' => false, 'message' => 'No recording URL available']);
+        exit(1);
+    }
+
+    try {
+        $path = $ringover->downloadRecording($mapped['recording_url']);
+        log_line('Recording downloaded to ' . $path);
+    } catch (Throwable $e) {
+        log_line('Recording download failed: ' . $e->getMessage());
+        echo json_encode(['success' => false, 'message' => 'Recording download failed']);
+        exit(1);
+    }
+
+    echo json_encode(['success' => true, 'calls' => $count]);
+    exit(0);
+} catch (Throwable $e) {
+    log_line('Unexpected error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add admin script to programmatically configure Ringover webhooks and guide manual setup if unsupported
- add integration test endpoint that validates Ringover auth, fetches calls, writes to DB, downloads a recording, and logs results

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895bbd8ef3c832aa6bd77325b25fc5f