### PR TITLE
Add Ringover webhook routes and CORS preflight handling

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -279,6 +279,22 @@ private function registerServices(): void
                 $router->post('/webhooks/ringover/record-available', 'RingoverWebhookController@recordAvailable');
                 $router->post('/webhooks/ringover/voicemail-available', 'RingoverWebhookController@voicemailAvailable');
 
+                // Allow preflight CORS requests and bypass CSRF
+                $router->options('/webhooks/ringover/record-available', function() {
+                    return new Response('', 204, [
+                        'Access-Control-Allow-Origin' => '*',
+                        'Access-Control-Allow-Methods' => 'POST, OPTIONS',
+                        'Access-Control-Allow-Headers' => 'Content-Type, X-Ringover-Signature'
+                    ]);
+                });
+                $router->options('/webhooks/ringover/voicemail-available', function() {
+                    return new Response('', 204, [
+                        'Access-Control-Allow-Origin' => '*',
+                        'Access-Control-Allow-Methods' => 'POST, OPTIONS',
+                        'Access-Control-Allow-Headers' => 'Content-Type, X-Ringover-Signature'
+                    ]);
+                });
+
                 // Sync and token
                 $router->post('/sync/hourly', 'SyncController@hourly');
                 $router->post('/sync/manual', 'SyncController@manual');


### PR DESCRIPTION
## Summary
- Expose Ringover webhook endpoints under `/api/v3` and add OPTIONS handlers that skip CSRF/CORS restrictions
- Extend Router to support callable/OPTIONS routes enabling simple preflight responses

## Testing
- `php -l app/Core/Router.php`
- `php -l app/Core/Application.php`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895c8a2d2dc832aae4a4362591aef5d