### PR TITLE
Add idempotent call recordings migration

### DIFF
--- a/database/migrations/2024XX_add_call_recordings.sql
+++ b/database/migrations/2024XX_add_call_recordings.sql
@@ -1,0 +1,14 @@
+-- Example idempotent migration for call recordings support.
+CREATE TABLE IF NOT EXISTS call_recordings (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    call_id BIGINT NOT NULL,
+    file_path VARCHAR(500) NOT NULL,
+    file_size INT,
+    duration INT,
+    format VARCHAR(10) DEFAULT 'mp3',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE calls
+    ADD COLUMN IF NOT EXISTS recording_path VARCHAR(500),
+    ADD COLUMN IF NOT EXISTS has_recording TINYINT(1) DEFAULT 0;


### PR DESCRIPTION
## Summary
- add migration creating `call_recordings` table
- add `recording_path` and `has_recording` columns to `calls`

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6895cd34de28832a873ff09fee7839fc