### PR TITLE
Add Ringover service test coverage and integration stub

### DIFF
--- a/tests/IntegrationFlowTest.php
+++ b/tests/IntegrationFlowTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class IntegrationFlowTest extends TestCase
+{
+    public function testEndToEndFlow()
+    {
+        if (!getenv('RUN_INTEGRATION_TESTS')) {
+            $this->markTestSkipped('Integration tests are disabled');
+        }
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add test for Ringover field mapping and request retry/backoff
- cover downloadRecording redirects, size limit, and filename sanitization
- include optional end-to-end integration test stub

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895ce681b4c832a9c04666f1fbbc4a3