### PR TITLE
feat: enhance Ringover call sync

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -104,7 +104,7 @@ try {
         $result = $repo->insertOrIgnore($mapped);
         if ($download && !empty($mapped['recording_url'])) {
             writeLog(LOG_LEVEL_INFO, 'Downloading recording', ['url' => $mapped['recording_url']]);
-            $ringoverService->downloadRecording($mapped['recording_url']);
+            $ringoverService->downloadRecording($mapped['recording_url'], 'recordings');
         }
         if ($result > 0) {
             $inserted++;

--- a/admin/api/test_ringover_integration.php
+++ b/admin/api/test_ringover_integration.php
@@ -71,8 +71,8 @@ try {
     }
 
     try {
-        $path = $ringover->downloadRecording($mapped['recording_url']);
-        log_line('Recording downloaded to ' . $path);
+        $info = $ringover->downloadRecording($mapped['recording_url'], 'recordings');
+        log_line('Recording downloaded to ' . $info['path']);
     } catch (Throwable $e) {
         log_line('Recording download failed: ' . $e->getMessage());
         echo json_encode(['success' => false, 'message' => 'Recording download failed']);

--- a/app/Controllers/RingoverWebhookController.php
+++ b/app/Controllers/RingoverWebhookController.php
@@ -29,9 +29,9 @@ class RingoverWebhookController extends BaseController
 
             /** @var RingoverService $ringover */
             $ringover = $this->service(RingoverService::class);
-            $localPath = $ringover->downloadRecording($data['recording_url'], 'storage/recordings');
+            $info = $ringover->downloadRecording($data['recording_url'], 'recordings');
 
-            $this->storeRecording($data['call_id'], $data['recording_url'], $localPath, $data['duration'] ?? 0);
+            $this->storeRecording($data['call_id'], $data['recording_url'], $info['path'], $info['duration']);
 
             return $this->successResponse(['stored' => true]);
         } catch (\Exception $e) {
@@ -57,9 +57,9 @@ class RingoverWebhookController extends BaseController
 
             /** @var RingoverService $ringover */
             $ringover = $this->service(RingoverService::class);
-            $localPath = $ringover->downloadRecording($data['voicemail_url'], 'storage/voicemails');
+            $info = $ringover->downloadVoicemail($data['voicemail_url']);
 
-            $this->storeRecording($data['call_id'], $data['voicemail_url'], $localPath, $data['duration'] ?? 0);
+            $this->storeRecording($data['call_id'], $data['voicemail_url'], $info['path'], $info['duration']);
 
             return $this->successResponse(['stored' => true]);
         } catch (\Exception $e) {

--- a/tests/AdminApiTest.php
+++ b/tests/AdminApiTest.php
@@ -37,7 +37,7 @@ class AdminApiTest extends TestCase
 
         $this->container->instance(RingoverService::class, new class {
             public function getCalls($since){ return [['ringover_id' => 'r1', 'recording_url'=>null]]; }
-            public function downloadRecording($url){}
+            public function downloadRecording($url, $subdir = 'recordings'){ return ['path'=>'', 'size'=>0, 'duration'=>0, 'format'=>'mp3']; }
             public function mapCallFields($call){ return $call; }
         });
         $this->container->alias(RingoverService::class, 'ringoverService');

--- a/tests/RingoverWebhookControllerTest.php
+++ b/tests/RingoverWebhookControllerTest.php
@@ -46,12 +46,12 @@ class RingoverWebhookControllerTest extends TestCase
         $c = $this->container($pdo, $secret);
         $c->instance(RingoverService::class, new class extends RingoverService {
             public function __construct(){}
-            public function downloadRecording(string $url, string $dir = 'storage/recordings'): string
+            public function downloadRecording(string $url, string $dir = 'storage/recordings'): array
             {
                 if (!is_dir($dir)) { mkdir($dir, 0755, true); }
                 $path = $dir . '/test.mp3';
                 file_put_contents($path, 'data');
-                return $path;
+                return ['path' => $path, 'size' => 4, 'duration' => 0, 'format' => 'mp3'];
             }
         });
 


### PR DESCRIPTION
## Summary
- paginate Ringover calls across offset or page-based APIs
- map Ringover call payloads to comprehensive database fields
- refactor recording downloads to return metadata and add voicemail helper

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6896087b2a5c832a83e06351c3239513