### PR TITLE
Ensure storage directories exist and add Ringover env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,11 @@ DB_PORT=3306
 DB_NAME=flujo_dimen_db
 DB_USER=user
 DB_PASS=secret
+
+# Ringover configuration
 RINGOVER_API_URL=https://public-api.ringover.com/v2
 RINGOVER_API_KEY=your-ringover-key
-RINGOVER_WEBHOOK_SECRET=
+RINGOVER_WEBHOOK_SECRET=your-webhook-secret
 RINGOVER_MAX_RECORDING_MB=100
 OPENAI_API_URL=https://api.openai.com/v1
 OPENAI_API_KEY=your-openai-key

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -25,6 +25,7 @@ class Application
         $this->initializeCore();
         $this->registerServices();
         $this->setupErrorHandling();
+        $this->ensureStorageDirectories();
     }
     
     /**
@@ -196,6 +197,23 @@ private function registerServices(): void
         set_error_handler([$this->errorHandler, 'handleError']);
         set_exception_handler([$this->errorHandler, 'handleException']);
         register_shutdown_function([$this->errorHandler, 'handleShutdown']);
+    }
+
+    /**
+     * Ensure recordings and voicemails storage directories exist and are writable.
+     */
+    private function ensureStorageDirectories(): void
+    {
+        $base = dirname(__DIR__, 2) . '/storage';
+        foreach (['recordings', 'voicemails'] as $subdir) {
+            $path = $base . '/' . $subdir;
+            if (!is_dir($path) && !mkdir($path, 0775, true) && !is_dir($path)) {
+                throw new \RuntimeException("Unable to create directory: {$path}");
+            }
+            if (!is_writable($path)) {
+                throw new \RuntimeException("Directory {$path} is not writable");
+            }
+        }
     }
     
     /**

--- a/tests/StorageDirectoriesTest.php
+++ b/tests/StorageDirectoriesTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Tests;
+
+use FlujosDimension\Core\Application;
+use PHPUnit\Framework\TestCase;
+
+class StorageDirectoriesTest extends TestCase
+{
+    public function testDirectoriesCreatedOnBootstrap(): void
+    {
+        $base = dirname(__DIR__) . '/storage';
+        @rmdir($base . '/recordings');
+        @rmdir($base . '/voicemails');
+
+        $this->assertFalse(is_dir($base . '/recordings'));
+        $this->assertFalse(is_dir($base . '/voicemails'));
+
+        new Application();
+        // Reset handlers installed during bootstrap to avoid risky test notices
+        restore_error_handler();
+        restore_exception_handler();
+
+        $this->assertDirectoryExists($base . '/recordings');
+        $this->assertDirectoryIsWritable($base . '/recordings');
+        $this->assertDirectoryExists($base . '/voicemails');
+        $this->assertDirectoryIsWritable($base . '/voicemails');
+    }
+}


### PR DESCRIPTION
## Summary
- document Ringover API configuration defaults in example environment file
- create and validate writable `storage/recordings` and `storage/voicemails` directories during bootstrap
- add test to confirm storage directories are initialized on application startup

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68961a35a498832aad885190934e09a5