### PR TITLE
feat(admin): allow custom Ringover sync range

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -51,7 +51,10 @@ if (!function_exists('writeLog')) {
 if (!function_exists('parseSince')) {
     function parseSince(string $sinceStr): \DateTimeImmutable {
         try {
-            return new \DateTimeImmutable($sinceStr);
+            // Allow HTML datetime-local ("Y-m-dTH:i") or "Y-m-d H:i"
+            $sinceStr = str_replace('T', ' ', $sinceStr);
+            $tz = new \DateTimeZone('Europe/Madrid');
+            return new \DateTimeImmutable($sinceStr, $tz);
         } catch (\Exception $e) {
             writeLog(LOG_LEVEL_ERROR, 'Invalid since parameter', [
                 'since' => $sinceStr,

--- a/admin/index.php
+++ b/admin/index.php
@@ -482,6 +482,11 @@ $apisStatus  = apiHealth();
         </tr><?php endforeach;?></tbody></table>
 
         <!-- SINCRONIZACIONES -->
+        <div class="form-row" style="margin:10px 0;gap:10px;align-items:center;">
+            <label for="ringover_since">Sincronizar llamadas desde:</label>
+            <input type="datetime-local" id="ringover_since" value="<?=date('Y-m-d\\TH:i',strtotime('-24 hours'))?>">
+            <label><input type="checkbox" id="ringover_download" checked> Descargar grabaciones</label>
+        </div>
         <button class="btn" id="btn-sync-ringover">📥 Sync Ringover</button>
         <button class="btn" id="btn-batch-openai">🤖 Batch OpenAI</button>
         <button class="btn" id="btn-push-crm">🏢 Push Pipedrive</button>
@@ -550,7 +555,11 @@ document.getElementById('btn-make-token').onclick=async()=>{
 /* --------- Sync Ringover --------- */
 document.getElementById('btn-sync-ringover').onclick=async()=>{
   setStatus('Sincronizando Ringover…');
-  const fd=new FormData();fd.append('download',1);
+  const fd=new FormData();
+  const since=document.getElementById('ringover_since').value;
+  if(since) fd.append('since', since);
+  const dl=document.getElementById('ringover_download').checked?'1':'0';
+  fd.append('download', dl);
   const r=await post('api/sync_ringover.php',fd);
   setStatus('Insertadas '+r.inserted+' llamadas');
 };

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -412,6 +412,13 @@
             <?php else: ?>
                 <p>No hay llamadas registradas aún. Los datos se mostrarán aquí cuando se sincronicen las llamadas desde Ringover.</p>
             <?php endif; ?>
+
+            <div class="form-group" style="margin-top:20px;">
+                <label for="ringover_since">Sincronizar llamadas desde:</label>
+                <input type="datetime-local" id="ringover_since" class="form-control" value="<?= date('Y-m-d\\TH:i', strtotime('-24 hours')) ?>">
+                <label><input type="checkbox" id="ringover_download" checked> Descargar grabaciones</label>
+                <button id="syncRingover" class="btn btn-primary" style="margin-left:10px;">Sync Ringover</button>
+            </div>
         </div>
 
         <!-- Salud del Sistema -->
@@ -621,10 +628,25 @@
                 });
             }
         }
-        
+
         function testEndpoint(endpoint, method) {
             alert('Funcionalidad de test de endpoint en desarrollo.\n\nEndpoint: ' + method + ' ' + endpoint);
         }
+
+        // Sync Ringover handler
+        document.getElementById('syncRingover').addEventListener('click', function() {
+            const since = document.getElementById('ringover_since').value;
+            const download = document.getElementById('ringover_download').checked ? '1' : '0';
+            const fd = new FormData();
+            if (since) fd.append('since', since);
+            fd.append('download', download);
+            fetch('api/sync_ringover.php', {method: 'POST', body: fd})
+                .then(r => r.json())
+                .then(data => {
+                    alert('Sincronización completa: ' + data.inserted + ' llamadas insertadas');
+                })
+                .catch(err => alert('Error en sincronización: ' + err));
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add UI controls to pick Ringover sync start date and toggle recording downloads
- Pass selected `since` and `download` values when syncing Ringover calls
- Parse custom `since` parameter with Europe/Madrid timezone support

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68971459f540832a88247b67a7404862