### PR TITLE
feat: update Ringover integration to use call_list and cdr_id

### DIFF
--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -64,6 +64,10 @@ final class CallRepository
      */
     public function insertOrIgnore(array $call): int
     {
+        if (empty($call['ringover_id'])) {
+            return 0;
+        }
+
         $driver = $this->db->getAttribute(PDO::ATTR_DRIVER_NAME);
         $prefix = $driver === 'sqlite' ? 'INSERT OR IGNORE' : 'INSERT IGNORE';
 

--- a/database/migrations/2024XX_add_unique_ringover_id.sql
+++ b/database/migrations/2024XX_add_unique_ringover_id.sql
@@ -1,0 +1,3 @@
+-- Ensure unique ringover_id values
+ALTER TABLE calls
+    ADD UNIQUE INDEX IF NOT EXISTS calls_ringover_id_unique (ringover_id);

--- a/docs/ringover_sync.md
+++ b/docs/ringover_sync.md
@@ -1,0 +1,43 @@
+# Ringover Sync
+
+Esta documentación describe la sincronización de llamadas con Ringover utilizando la estructura actual de la API.
+
+## Estructura de la respuesta
+
+La API devuelve las llamadas dentro de la clave `call_list`. Cada elemento contiene el identificador `cdr_id` y otros campos opcionales:
+
+```json
+{
+  "total_call_count": 2,
+  "call_list_count": 2,
+  "call_list": [
+    {
+      "cdr_id": "123",
+      "from_number": "+34900111222",
+      "contact_number": "+34900999888"
+    }
+  ]
+}
+```
+
+## Paginación
+
+Se utilizan parámetros `page` y `limit`. El servicio incrementa `page` hasta procesar todas las llamadas.
+
+## Mapeo de campos
+
+- `cdr_id` → `ringover_id`
+- `from_number` → `phone_number`
+- `contact_number` → `contact_number`
+- `call_start` → `start_time`
+
+## Validaciones adicionales
+
+- Si `call_list` está vacío se detiene la iteración y se registra un error.
+- Si una llamada no tiene `ringover_id`, se omite su inserción en la base de datos.
+
+## Despliegue
+
+1. Ejecutar las migraciones para asegurar índice único en `ringover_id`.
+2. Ejecutar `phpunit` para validar los cambios.
+3. Configurar los flujos de n8n con parámetros `page` y `limit`.


### PR DESCRIPTION
## Summary
- refactor RingoverService to consume call_list and cdr_id with page/limit pagination
- enhance sync script with pagination logging and ringover_id validation
- document updated Ringover sync behaviour and add migration for unique ringover_id

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897258531b8832a9ab57a21be54ad5b