### PR TITLE
Handle Ringover voicemail field and improve sync error reporting

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -191,5 +191,12 @@ try {
     writeLog(LOG_LEVEL_ERROR, 'Exception occurred', ['error' => $e->getMessage()]);
     $errors[] = ['type' => 'exception', 'message' => $e->getMessage()];
     http_response_code(500);
-    echo json_encode(['success' => false, 'message' => $e->getMessage(), 'errors' => $errors]);
+    echo json_encode([
+        'success'   => false,
+        'message'   => $e->getMessage(),
+        'retrieved' => $retrieved ?? 0,
+        'inserted'  => $inserted ?? 0,
+        'downloads' => $downloads ?? 0,
+        'errors'    => $errors,
+    ]);
 }

--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -176,6 +176,8 @@ class RingoverService
             }
 
             $processed += $pageCount;
+            // debug log of page processing
+            error_log("RingoverService: processed page {$page} with {$pageCount} calls");
             if ($total !== null && $processed >= $total) {
                 break;
             }
@@ -231,8 +233,8 @@ class RingoverService
             'last_state'     => $lastState,
             'status'         => $status,
             'duration'       => $duration,
-            'recording_url'  => $call['recording_url'] ?? ($call['recording']       ?? null),
-            'voicemail_url'  => $call['voicemail_url'] ?? null,
+            'recording_url'  => $call['record']       ?? null,
+            'voicemail_url'  => $call['voicemail']    ?? null,
         ];
     }
 

--- a/database/migrations/2024XX_add_voicemail_url.sql
+++ b/database/migrations/2024XX_add_voicemail_url.sql
@@ -1,0 +1,3 @@
+-- Add voicemail_url column for storing Ringover voicemail links
+ALTER TABLE calls
+    ADD COLUMN IF NOT EXISTS voicemail_url TEXT AFTER recording_url;

--- a/docs/ringover_sync.md
+++ b/docs/ringover_sync.md
@@ -30,6 +30,8 @@ Se utilizan parámetros `page` y `limit`. El servicio incrementa `page` hasta pr
 - `from_number` → `phone_number`
 - `contact_number` → `contact_number`
 - `call_start` → `start_time`
+- `record` → `recording_url`
+- `voicemail` → `voicemail_url`
 
 ## Validaciones adicionales
 
@@ -38,6 +40,6 @@ Se utilizan parámetros `page` y `limit`. El servicio incrementa `page` hasta pr
 
 ## Despliegue
 
-1. Ejecutar las migraciones para asegurar índice único en `ringover_id`.
+1. Ejecutar las migraciones para asegurar índice único en `ringover_id` y la columna `voicemail_url`.
 2. Ejecutar `phpunit` para validar los cambios.
 3. Configurar los flujos de n8n con parámetros `page` y `limit`.

--- a/tests/RingoverServiceTest.php
+++ b/tests/RingoverServiceTest.php
@@ -89,7 +89,7 @@ class RingoverServiceTest extends TestCase
             'direction'      => 'out',
             'last_state'     => 'busy',
             'incall_duration'=> 7,
-            'recording_url'  => 'https://r.test/a.wav',
+            'record'         => 'https://r.test/a.wav',
             'call_start'     => '2024-01-01T00:00:00Z'
         ];
 
@@ -120,7 +120,7 @@ class RingoverServiceTest extends TestCase
             'direction'      => 'in',
             'is_answered'    => true,
             'total_duration' => 10,
-            'recording'      => 'https://r.test/b.wav',
+            'record'         => 'https://r.test/b.wav',
             'call_start'     => '2024-02-01T00:00:00Z'
         ];
 


### PR DESCRIPTION
## Summary
- add voicemail_url migration for calls table
- map Ringover `record` and `voicemail` fields and log processed pages
- return inserted/download counts when sync script errors

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68972d01633c832abe33388d0b8a286a