### PR TITLE
Use absolute storage paths for Ringover downloads

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -19,6 +19,16 @@ if (!is_dir($logDir)) {
 }
 $GLOBALS['logFile'] = $logDir . '/sync_ringover.log';
 
+// Base storage directories
+$baseStorage   = dirname(__DIR__, 2) . '/storage';
+$recordingsDir = $baseStorage . '/recordings';
+$voicemailsDir = $baseStorage . '/voicemails';
+foreach ([$recordingsDir, $voicemailsDir] as $dir) {
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+}
+
 if (!function_exists('determine_log_level')) {
     function determine_log_level(Request $request): int {
         $value = $request->get('log_level') ?? $request->post('log_level') ?? getenv('RINGOVER_LOG_LEVEL');
@@ -142,10 +152,10 @@ try {
             try {
                 if (!empty($mapped['recording_url']) && method_exists($ringoverService, 'downloadRecording')) {
                     writeLog(LOG_LEVEL_INFO, 'Downloading recording', ['url' => $mapped['recording_url']]);
-                    $info = $ringoverService->downloadRecording($mapped['recording_url'], 'recordings');
-                } elseif (!empty($mapped['voicemail_url']) && method_exists($ringoverService, 'downloadVoicemail')) {
+                    $info = $ringoverService->downloadRecording($mapped['recording_url'], $recordingsDir);
+                } elseif (!empty($mapped['voicemail_url']) && method_exists($ringoverService, 'downloadRecording')) {
                     writeLog(LOG_LEVEL_INFO, 'Downloading voicemail', ['url' => $mapped['voicemail_url']]);
-                    $info = $ringoverService->downloadVoicemail($mapped['voicemail_url']);
+                    $info = $ringoverService->downloadRecording($mapped['voicemail_url'], $voicemailsDir);
                 } else {
                     $info = null;
                 }

--- a/admin/api/test_ringover_integration.php
+++ b/admin/api/test_ringover_integration.php
@@ -24,6 +24,9 @@ try {
     /** @var CallRepository $repo */
     $repo     = $container->resolve('callRepository');
 
+    $baseStorage   = dirname(__DIR__, 2) . '/storage';
+    $recordingsDir = $baseStorage . '/recordings';
+
     $params = validate_input($request, [
         'start_date' => ['filter' => FILTER_UNSAFE_RAW, 'required' => true],
     ]);
@@ -72,7 +75,7 @@ try {
     }
 
     try {
-        $info = $ringover->downloadRecording($mapped['recording_url'], 'recordings');
+        $info = $ringover->downloadRecording($mapped['recording_url'], $recordingsDir);
         log_line('Recording downloaded to ' . $info['path']);
     } catch (Throwable $e) {
         log_line('Recording download failed: ' . $e->getMessage());

--- a/app/Controllers/RingoverWebhookController.php
+++ b/app/Controllers/RingoverWebhookController.php
@@ -32,7 +32,9 @@ class RingoverWebhookController extends BaseController
 
             /** @var RingoverService $ringover */
             $ringover = $this->service(RingoverService::class);
-            $info = $ringover->downloadRecording($data['recording_url'], 'recordings');
+            $storageDir   = dirname(__DIR__, 2) . '/storage';
+            $recordingsDir = $storageDir . '/recordings';
+            $info = $ringover->downloadRecording($data['recording_url'], $recordingsDir);
 
             /** @var CallRepository $repo */
             $repo = $this->service(CallRepository::class);
@@ -80,7 +82,9 @@ class RingoverWebhookController extends BaseController
 
             /** @var RingoverService $ringover */
             $ringover = $this->service(RingoverService::class);
-            $info = $ringover->downloadVoicemail($data['voicemail_url']);
+            $storageDir    = dirname(__DIR__, 2) . '/storage';
+            $voicemailsDir = $storageDir . '/voicemails';
+            $info = $ringover->downloadVoicemail($data['voicemail_url'], $voicemailsDir);
 
             /** @var CallRepository $repo */
             $repo = $this->service(CallRepository::class);

--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -349,9 +349,9 @@ class RingoverService
         ];
     }
 
-    public function downloadVoicemail(string $url): array
+    public function downloadVoicemail(string $url, string $dir = 'voicemails'): array
     {
-        return $this->downloadRecording($url, 'voicemails');
+        return $this->downloadRecording($url, $dir);
     }
 }
 

--- a/tests/StorageDirectoriesTest.php
+++ b/tests/StorageDirectoriesTest.php
@@ -9,11 +9,18 @@ class StorageDirectoriesTest extends TestCase
     public function testDirectoriesCreatedOnBootstrap(): void
     {
         $base = dirname(__DIR__) . '/storage';
-        @rmdir($base . '/recordings');
-        @rmdir($base . '/voicemails');
 
-        $this->assertFalse(is_dir($base . '/recordings'));
-        $this->assertFalse(is_dir($base . '/voicemails'));
+        foreach (['recordings', 'voicemails'] as $sub) {
+            $dir = $base . '/' . $sub;
+            if (is_dir($dir)) {
+                $files = glob($dir . '/*');
+                if ($files !== false) {
+                    array_map('unlink', $files);
+                }
+                @rmdir($dir);
+            }
+            $this->assertFalse(is_dir($dir));
+        }
 
         new Application();
         // Reset handlers installed during bootstrap to avoid risky test notices


### PR DESCRIPTION
## Summary
- Initialize base storage directories and ensure recordings and voicemails use absolute paths
- Allow `downloadVoicemail` to target a custom directory
- Update Ringover webhook and integration scripts to download using absolute storage locations

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68985de9a3e0832a9de006c220b8ceb6