### PR TITLE
Mark recordings for pending analysis

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -148,6 +148,10 @@ try {
 
         $hasMedia = !empty($mapped['recording_url']) || !empty($mapped['voicemail_url']);
 
+        if ($hasMedia && $callId !== null && method_exists($repo, 'setPendingAnalysis')) {
+            $repo->setPendingAnalysis($callId, true);
+        }
+
         if ($full && $hasMedia && $callId !== null) {
             try {
                 if (!empty($mapped['recording_url']) && method_exists($ringoverService, 'downloadRecording')) {

--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -14,6 +14,8 @@ final class CallRepository
     {
         $sql = 'SELECT * FROM calls
                 WHERE pending_analysis = 1
+                  AND has_recording = 1
+                  AND (recording_path IS NOT NULL AND recording_path <> \'\')
                 ORDER BY created_at ASC
                 LIMIT :max';
 
@@ -116,6 +118,15 @@ final class CallRepository
         $stmt->execute([':rid' => $ringoverId]);
         $id = $stmt->fetchColumn();
         return $id === false ? null : (int)$id;
+    }
+
+    /**
+     * Mark whether a call is pending AI analysis.
+     */
+    public function setPendingAnalysis(int $callId, bool $pending): void
+    {
+        $stmt = $this->db->prepare('UPDATE calls SET pending_analysis = :p WHERE id = :id');
+        $stmt->execute([':p' => $pending ? 1 : 0, ':id' => $callId]);
     }
 
     /**


### PR DESCRIPTION
## Summary
- filter CallRepository::pending() by recording status
- add repository helper to set pending analysis flag
- flag calls with media for analysis during Ringover sync
- test repository pending analysis features

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6898614b2db8832aa291daefe87f8bab