### PR TITLE
Prefer local recording path in analytics

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -179,7 +179,8 @@ private function registerServices(): void
         \FlujosDimension\Services\AnalyticsService::class,            // <- ruta exacta: app\Services\AnalyticsService.php
         fn ($c) => new \FlujosDimension\Services\AnalyticsService(
             $c->resolve('callRepository'),
-            $c->resolve(\FlujosDimension\Services\OpenAIService::class)
+            $c->resolve(\FlujosDimension\Services\OpenAIService::class),
+            $c->resolve('logger')
         )
     );
     $this->container->alias(

--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -15,7 +15,7 @@ final class CallRepository
         $sql = 'SELECT * FROM calls
                 WHERE pending_analysis = 1
                   AND has_recording = 1
-                  AND (recording_path IS NOT NULL AND recording_path <> \'\')
+                  AND COALESCE(recording_path, "") <> ""
                 ORDER BY created_at ASC
                 LIMIT :max';
 

--- a/tests/DashboardControllerTest.php
+++ b/tests/DashboardControllerTest.php
@@ -61,7 +61,7 @@ class DashboardControllerTest extends TestCase
         $pdo = new \PDO('sqlite::memory:');
         $repo = new CallRepository($pdo);
         $openai = new OpenAIService(new HttpClient(['handler' => HandlerStack::create(new MockHandler())]), 'k');
-        $analytics = new AnalyticsService($repo, $openai);
+        $analytics = new AnalyticsService($repo, $openai, new \FlujosDimension\Core\Logger(sys_get_temp_dir()));
         $container->instance('analyticsService', $analytics);
         $container->instance('ringoverService', new DummyRingover());
         $_GET = [];
@@ -88,7 +88,7 @@ class DashboardControllerTest extends TestCase
         $pdo = new \PDO('sqlite::memory:');
         $repo = new CallRepository($pdo);
         $openai = new OpenAIService(new HttpClient(['handler' => HandlerStack::create(new MockHandler())]), 'k');
-        $analytics = new AnalyticsService($repo, $openai);
+        $analytics = new AnalyticsService($repo, $openai, new \FlujosDimension\Core\Logger(sys_get_temp_dir()));
         $cacheDir = sys_get_temp_dir() . '/fd-cache';
         if (!is_dir($cacheDir)) { mkdir($cacheDir); }
         file_put_contents($cacheDir . '/test.cache', 'x');
@@ -124,7 +124,7 @@ class DashboardControllerTest extends TestCase
 
         $repo = new CallRepository($pdo);
         $openai = new OpenAIService(new HttpClient(['handler' => HandlerStack::create(new MockHandler())]), 'k');
-        $analytics = new AnalyticsService($repo, $openai);
+        $analytics = new AnalyticsService($repo, $openai, new \FlujosDimension\Core\Logger(sys_get_temp_dir()));
         $container->instance('analyticsService', $analytics);
         $container->instance('ringoverService', new DummyRingover());
 


### PR DESCRIPTION
## Summary
- Use local recording_path when available during analytics processing, falling back to recording_url and logging missing paths
- Filter pending calls to only those with non-empty recording_path
- Inject logger into AnalyticsService via Application container

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68986bef9004832a80c5e2e99a900a0a