### PR TITLE
Handle Ringover call status field

### DIFF
--- a/app/Services/RingoverService.php
+++ b/app/Services/RingoverService.php
@@ -205,13 +205,11 @@ class RingoverService
             default => $directionRaw,
         };
 
-        $lastState  = $call['last_state'] ?? null;
-        $answered   = $call['is_answered'] ?? null;
-        $status     = null;
-        if ($lastState !== null) {
-            if (in_array($lastState, ['busy', 'failed'], true)) {
-                $status = $lastState;
-            }
+        $lastState = $call['last_state'] ?? ($call['status'] ?? null);
+        $answered  = $call['is_answered'] ?? null;
+        $status    = $lastState;
+        if ($status !== null && !in_array($status, ['busy', 'failed', 'answered', 'missed'], true)) {
+            $status = null;
         }
         if ($status === null && $answered !== null) {
             $status = $answered ? 'answered' : 'missed';


### PR DESCRIPTION
## Summary
- derive call `status` from Ringover's `last_state`/`status` fields and ignore invalid values

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6898e25150b4832aabe6c277213c7ade