### PR TITLE
Sanitize config handling and document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,28 @@
 # Example environment configuration for Flujos Dimension
+
+# Database connection
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=flujo_dimen_db
 DB_USER=user
 DB_PASS=secret
 
-# Ringover configuration
+# Ringover API
 RINGOVER_API_URL=https://public-api.ringover.com/v2
 RINGOVER_API_KEY=your-ringover-key
 RINGOVER_WEBHOOK_SECRET=your-webhook-secret
 RINGOVER_MAX_RECORDING_MB=100
+
+# OpenAI API
 OPENAI_API_URL=https://api.openai.com/v1
 OPENAI_API_KEY=your-openai-key
 OPENAI_MODEL=gpt-4o-transcribe
+
+# Pipedrive API
 PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_API_TOKEN=your-pipedrive-token
+
+# Security
 JWT_SECRET=change-me
 ADMIN_USER=admin
 # password_hash('password', PASSWORD_DEFAULT)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ This project automates the synchronization of Ringover calls with OpenAI process
 ```bash
 composer install
 cp .env.example .env
-# Edit `.env` and set `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` and `DB_PASS`
-# along with your API credentials. The variable
+# Edit `.env` and set database values (`DB_HOST`, `DB_PORT`, `DB_NAME`,
+# `DB_USER`, `DB_PASS`) plus `RINGOVER_API_KEY`, `PIPEDRIVE_API_TOKEN`,
+# `OPENAI_API_KEY` and `JWT_SECRET`. The variable
 # `RINGOVER_MAX_RECORDING_MB` limits the size of downloaded
 # recordings (default 100).
 mkdir -p storage/recordings storage/voicemails

--- a/admin/views/env_editor.php
+++ b/admin/views/env_editor.php
@@ -296,8 +296,7 @@
                 </div>
                 <div class="form-group">
                     <label for="DB_PASS">Contraseña de Base de Datos</label>
-                    <input type="password" id="DB_PASS" name="DB_PASS" 
-                           value="<?php echo htmlspecialchars($this->config->get('DB_PASS', '')); ?>" required>
+                    <input type="password" id="DB_PASS" name="DB_PASS" placeholder="********" required>
                 </div>
                 
                 <div class="section-title">📞 API Ringover</div>
@@ -308,15 +307,13 @@
                                value="<?php echo htmlspecialchars($this->config->get('RINGOVER_API_URL', 'https://public-api.ringover.com/v2')); ?>" required>
                     </div>
                     <div class="form-group">
-                        <label for="RINGOVER_API_KEY">Clave de API Ringover</label>
-                        <input type="text" id="RINGOVER_API_KEY" name="RINGOVER_API_KEY"
-                               value="<?php echo htmlspecialchars($this->config->get('RINGOVER_API_KEY', '')); ?>" required>
+                          <label for="RINGOVER_API_KEY">Clave de API Ringover</label>
+                          <input type="password" id="RINGOVER_API_KEY" name="RINGOVER_API_KEY" placeholder="********" required>
                         <button type="button" class="test-btn" onclick="testRingoverApi()">Probar</button>
                     </div>
                     <div class="form-group">
-                        <label for="RINGOVER_WEBHOOK_SECRET">Secreto de Webhook</label>
-                        <input type="text" id="RINGOVER_WEBHOOK_SECRET" name="RINGOVER_WEBHOOK_SECRET"
-                               value="<?php echo htmlspecialchars($this->config->get('RINGOVER_WEBHOOK_SECRET', '')); ?>">
+                          <label for="RINGOVER_WEBHOOK_SECRET">Secreto de Webhook</label>
+                          <input type="password" id="RINGOVER_WEBHOOK_SECRET" name="RINGOVER_WEBHOOK_SECRET" placeholder="********">
                     </div>
                     <div class="form-group">
                         <label for="RINGOVER_MAX_RECORDING_MB">Tamaño máximo grabación (MB)</label>
@@ -333,9 +330,8 @@
                                value="<?php echo htmlspecialchars($this->config->get('OPENAI_API_URL', 'https://api.openai.com/v1')); ?>" required>
                     </div>
                     <div class="form-group">
-                        <label for="OPENAI_API_KEY">Clave de API OpenAI</label>
-                        <input type="text" id="OPENAI_API_KEY" name="OPENAI_API_KEY" 
-                               value="<?php echo htmlspecialchars($this->config->get('OPENAI_API_KEY', '')); ?>" required>
+                          <label for="OPENAI_API_KEY">Clave de API OpenAI</label>
+                          <input type="password" id="OPENAI_API_KEY" name="OPENAI_API_KEY" placeholder="********" required>
                         <button type="button" class="test-btn" onclick="testOpenAiApi()">Probar</button>
                     </div>
                 </div>
@@ -348,9 +344,8 @@
                                value="<?php echo htmlspecialchars($this->config->get('PIPEDRIVE_API_URL', 'https://api.pipedrive.com/v1')); ?>" required>
                     </div>
                     <div class="form-group">
-                        <label for="PIPEDRIVE_API_TOKEN">Token de API Pipedrive</label>
-                        <input type="text" id="PIPEDRIVE_API_TOKEN" name="PIPEDRIVE_API_TOKEN" 
-                               value="<?php echo htmlspecialchars($this->config->get('PIPEDRIVE_API_TOKEN', '')); ?>" required>
+                          <label for="PIPEDRIVE_API_TOKEN">Token de API Pipedrive</label>
+                          <input type="password" id="PIPEDRIVE_API_TOKEN" name="PIPEDRIVE_API_TOKEN" placeholder="********" required>
                         <button type="button" class="test-btn" onclick="testPipedriveApi()">Probar</button>
                     </div>
                 </div>
@@ -358,9 +353,8 @@
                 <div class="section-title">🔐 Seguridad y JWT</div>
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="JWT_SECRET">Clave Secreta JWT</label>
-                        <input type="text" id="JWT_SECRET" name="JWT_SECRET" 
-                               value="<?php echo htmlspecialchars($this->config->get('JWT_SECRET', '')); ?>" required>
+                          <label for="JWT_SECRET">Clave Secreta JWT</label>
+                          <input type="password" id="JWT_SECRET" name="JWT_SECRET" placeholder="********" required>
                         <div class="help-text">Mínimo 32 caracteres para mayor seguridad</div>
                     </div>
                     <div class="form-group">

--- a/app/Controllers/ConfigController.php
+++ b/app/Controllers/ConfigController.php
@@ -17,7 +17,20 @@ class ConfigController extends BaseController
     {
         try {
             $config = Config::getInstance();
-            return $this->successResponse($config->all());
+            $data   = $config->all();
+            $sensitive = [
+                'RINGOVER_API_KEY',
+                'PIPEDRIVE_API_TOKEN',
+                'OPENAI_API_KEY',
+                'JWT_SECRET',
+                'DB_PASS',
+            ];
+            foreach ($sensitive as $key) {
+                if (isset($data[$key])) {
+                    $data[$key] = '[hidden]';
+                }
+            }
+            return $this->successResponse($data);
         } catch (\Exception $e) {
             return $this->handleError($e, 'Error loading configuration');
         }

--- a/app/Core/Config.php
+++ b/app/Core/Config.php
@@ -10,7 +10,6 @@ namespace FlujosDimension\Core;
 class Config
 {
     private static $instance = null;
-    private $config = [];
     private $envLoaded = false;
     
     private function __construct()
@@ -62,12 +61,11 @@ class Config
                     // Establecer variable de entorno
                     putenv("$key=$value");
                     $_ENV[$key] = $value;
-                    $this->config[$key] = $value;
                 }
             }
             
             $this->envLoaded = true;
-            $this->logInfo("Environment variables loaded successfully. Total: " . count($this->config));
+            $this->logInfo("Environment variables loaded successfully. Total: " . count($_ENV));
             return true;
             
         } catch (Exception $e) {
@@ -81,20 +79,16 @@ class Config
      */
     public function get($key, $default = null)
     {
-        // Prioridad: config cargado > $_ENV > getenv() > default
-        if (isset($this->config[$key])) {
-            return $this->config[$key];
-        }
-        
+        // Prioridad: $_ENV > getenv() > default
         if (isset($_ENV[$key])) {
             return $_ENV[$key];
         }
-        
+
         $envValue = getenv($key);
         if ($envValue !== false) {
             return $envValue;
         }
-        
+
         return $default;
     }
     
@@ -103,7 +97,6 @@ class Config
      */
     public function set($key, $value)
     {
-        $this->config[$key] = $value;
         putenv("$key=$value");
         $_ENV[$key] = $value;
     }
@@ -113,7 +106,7 @@ class Config
      */
     public function has($key)
     {
-        return isset($this->config[$key]) || isset($_ENV[$key]) || getenv($key) !== false;
+        return isset($_ENV[$key]) || getenv($key) !== false;
     }
     
     /**
@@ -121,7 +114,7 @@ class Config
      */
     public function all()
     {
-        return array_merge($_ENV, $this->config);
+        return $_ENV;
     }
     
     /**

--- a/database/migrations/20240906120000_sanitize_system_config.sql
+++ b/database/migrations/20240906120000_sanitize_system_config.sql
@@ -1,0 +1,12 @@
+-- Anonymize sensitive values in system_config
+UPDATE system_config
+SET config_value = NULL
+WHERE config_key IN (
+    'openai.api_key',
+    'pipedrive.api_token',
+    'ringover.api_key',
+    'db.host',
+    'db.database',
+    'db.username',
+    'db.password'
+);

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,10 +8,11 @@
    ```bash
 cp .env.example .env
 ```
-   Edit `.env` and configure the database variables:
-   `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`.
-   Add your API tokens as needed.
-   The value of `ADMIN_PASS` should be generated with `password_hash`.
+   Edit `.env` and configure the database variables (`DB_HOST`, `DB_PORT`,
+   `DB_NAME`, `DB_USER`, `DB_PASS`) and API credentials
+   `RINGOVER_API_KEY`, `PIPEDRIVE_API_TOKEN`, `OPENAI_API_KEY`.
+   Also set `JWT_SECRET`. The value of `ADMIN_PASS` should be generated
+   with `password_hash`.
 3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server. The
    `api_tokens` table now stores a `token_hash` column instead of the raw token.
 4. **Launch the built-in PHP web server** for local testing.


### PR DESCRIPTION
## Summary
- group required environment variables in `.env.example` and docs
- load configuration strictly from environment and mask sensitive API keys in responses
- add SQL script to purge secrets from `system_config`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6899a6a606ec832a9544f70a3b159bbc