### PR TITLE
feat: add DTOs and validation

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -67,6 +67,35 @@ abstract class BaseController
         
         return $this->jsonResponse($response);
     }
+
+    /**
+     * Normalize and trim input strings. Phone fields are converted to E.164.
+     */
+    protected function normalizeInput(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $value = trim($value);
+                if (str_contains($key, 'phone')) {
+                    $value = $this->normalizePhone($value);
+                }
+                $data[$key] = $value;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Convert a phone number to E.164 format.
+     */
+    protected function normalizePhone(string $phone): string
+    {
+        $digits = preg_replace('/\D+/', '', $phone);
+        if (str_starts_with($digits, '00')) {
+            $digits = substr($digits, 2);
+        }
+        return $digits !== '' ? '+' . $digits : '';
+    }
     
     /**
      * Validar datos de entrada

--- a/app/DTO/AudioJobDTO.php
+++ b/app/DTO/AudioJobDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class AudioJobDTO
+{
+    public function __construct(
+        public string $callId,
+        public string $url,
+        public int $duration
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'call_id' => $this->callId,
+            'url'     => $this->url,
+            'duration'=> $this->duration,
+        ];
+    }
+}

--- a/app/DTO/CallMetadataDTO.php
+++ b/app/DTO/CallMetadataDTO.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class CallMetadataDTO
+{
+    public function __construct(
+        public string $phoneNumber,
+        public string $direction,
+        public string $status,
+        public ?int $duration = null
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'phone_number' => $this->phoneNumber,
+            'direction'    => $this->direction,
+            'status'       => $this->status,
+            'duration'     => $this->duration,
+        ];
+    }
+}

--- a/app/DTO/N8nSummaryDTO.php
+++ b/app/DTO/N8nSummaryDTO.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class N8nSummaryDTO
+{
+    public function __construct(
+        public int|string $callId,
+        public string $summary
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'call_id' => $this->callId,
+            'summary' => $this->summary,
+        ];
+    }
+}

--- a/app/DTO/NLPInsightsDTO.php
+++ b/app/DTO/NLPInsightsDTO.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class NLPInsightsDTO
+{
+    public function __construct(
+        public int|string $callId,
+        public ?string $summary = null,
+        public ?string $sentiment = null,
+        public array $keywords = []
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'call_id'  => $this->callId,
+            'summary'  => $this->summary,
+            'sentiment'=> $this->sentiment,
+            'keywords' => $this->keywords,
+        ];
+    }
+}

--- a/app/DTO/PipedriveUpdateDTO.php
+++ b/app/DTO/PipedriveUpdateDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class PipedriveUpdateDTO
+{
+    public function __construct(
+        public int|string $callId,
+        public ?int $dealId = null,
+        public ?int $contactId = null
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'call_id'   => $this->callId,
+            'deal_id'   => $this->dealId,
+            'contact_id'=> $this->contactId,
+        ];
+    }
+}

--- a/app/DTO/TranscriptionDTO.php
+++ b/app/DTO/TranscriptionDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FlujosDimension\DTO;
+
+class TranscriptionDTO
+{
+    public function __construct(
+        public int|string $callId,
+        public string $text,
+        public ?float $confidence = null
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'call_id'    => $this->callId,
+            'text'       => $this->text,
+            'confidence' => $this->confidence,
+        ];
+    }
+}

--- a/app/Support/Validator.php
+++ b/app/Support/Validator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace FlujosDimension\Support;
+
+class Validator
+{
+    /**
+     * Validate data against a set of rules.
+     * Returns an array of error messages indexed by field.
+     */
+    public static function validate(array $data, array $rules): array
+    {
+        $errors = [];
+
+        foreach ($rules as $field => $ruleString) {
+            $value = $data[$field] ?? null;
+            $ruleList = explode('|', $ruleString);
+
+            foreach ($ruleList as $rule) {
+                if ($rule === 'required') {
+                    if ($value === null || $value === '') {
+                        $errors[$field][] = "Field {$field} is required";
+                    }
+                    continue;
+                }
+
+                if ($value === null || $value === '') {
+                    continue; // Skip other rules if value not provided
+                }
+
+                if ($rule === 'string' && !is_string($value)) {
+                    $errors[$field][] = "Field {$field} must be a string";
+                } elseif ($rule === 'integer' && !self::isInteger($value)) {
+                    $errors[$field][] = "Field {$field} must be an integer";
+                } elseif (str_starts_with($rule, 'in:')) {
+                    $allowed = explode(',', substr($rule, 3));
+                    if (!in_array($value, $allowed, true)) {
+                        $errors[$field][] = "Field {$field} must be one of: " . implode(', ', $allowed);
+                    }
+                } elseif (str_starts_with($rule, 'format:')) {
+                    $format = substr($rule, 7);
+                    if (!self::validateFormat($value, $format)) {
+                        $errors[$field][] = "Field {$field} has invalid format";
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private static function isInteger($value): bool
+    {
+        return is_int($value) || (is_string($value) && ctype_digit($value));
+    }
+
+    private static function validateFormat($value, string $format): bool
+    {
+        return match ($format) {
+            'email' => filter_var($value, FILTER_VALIDATE_EMAIL) !== false,
+            'url'   => filter_var($value, FILTER_VALIDATE_URL) !== false,
+            'phone' => preg_match('/^\+[1-9]\d{7,14}$/', $value) === 1,
+            default => true,
+        };
+    }
+}

--- a/tests/ControllerActionsTest.php
+++ b/tests/ControllerActionsTest.php
@@ -50,7 +50,7 @@ class ControllerActionsTest extends TestCase
         $c->instance(Call::class, new CallModelStub());
         $controller = new CallsController($c, $this->request('POST','/api/v3/calls', []));
         $res = $controller->store();
-        $this->assertSame(400, $res->getStatusCode());
+        $this->assertSame(422, $res->getStatusCode());
         $data = json_decode($res->getContent(), true);
         $this->assertFalse($data['success']);
     }
@@ -60,7 +60,7 @@ class ControllerActionsTest extends TestCase
         $c = $this->container();
         $c->instance(Call::class, new CallModelStub());
         $controller = new CallsController($c, $this->request('POST','/api/v3/calls', [
-            'phone_number'=>'123','direction'=>'inbound','status'=>'answered','duration'=>5
+            'phone_number'=>'1234567890','direction'=>'inbound','status'=>'answered','duration'=>5
         ]));
         $res = $controller->store();
         $this->assertSame(201, $res->getStatusCode());


### PR DESCRIPTION
## Summary
- add DTO classes for calls, audio jobs, transcriptions, NLP insights, Pipedrive updates and N8n summaries
- introduce reusable Validator utility
- normalize and validate request data in Calls and Ringover webhook controllers
- adjust tests for 422 validation failures and E.164 phone numbers

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6899b782ccd0832a9166551737427e12