### PR TITLE
feat: add ringover fields and crm sync logs

### DIFF
--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -15,21 +15,26 @@ class Call extends BaseModel
     protected string $table = 'calls';
     protected array $sortable = [
         'id', 'created_at', 'updated_at', 'duration', 'status', 'direction',
-        'phone_number', 'ringover_id'
+        'phone_number', 'ringover_id', 'call_id', 'start_time'
     ];
     protected array $fillable = [
-        'ringover_id', 'phone_number', 'direction', 'status', 'duration',
-        'recording_url', 'ai_transcription', 'ai_summary', 'ai_keywords',
+        'ringover_id', 'call_id', 'phone_number', 'contact_number',
+        'caller_name', 'contact_name', 'direction', 'status', 'duration',
+        'recording_url', 'voicemail_url', 'start_time', 'total_duration',
+        'incall_duration', 'ai_transcription', 'ai_summary', 'ai_keywords',
         'ai_sentiment', 'pipedrive_contact_id', 'pipedrive_deal_id'
     ];
-    
+
     protected array $casts = [
         'id' => 'int',
         'duration' => 'int',
+        'total_duration' => 'int',
+        'incall_duration' => 'int',
         'pipedrive_contact_id' => 'int',
         'pipedrive_deal_id' => 'int',
         'created_at' => 'datetime',
-        'updated_at' => 'datetime'
+        'updated_at' => 'datetime',
+        'start_time' => 'datetime'
     ];
     
     /**

--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -188,6 +188,22 @@ final class CallRepository
             'UPDATE calls SET crm_synced = 1, pipedrive_deal_id = :dealId WHERE id = :id'
         );
         $stmt->execute([':dealId' => $dealId, ':id' => $id]);
+
+        $this->logCrmSync($id, 'success');
+    }
+
+    /** Log a CRM sync attempt */
+    public function logCrmSync(int $callId, string $result, ?string $errorMessage = null): void
+    {
+        $stmt = $this->db->prepare(
+            'INSERT INTO crm_sync_logs (call_id, result, error_message, created_at) VALUES (:call_id, :result, :error_message, :created_at)'
+        );
+        $stmt->execute([
+            ':call_id' => $callId,
+            ':result' => $result,
+            ':error_message' => $errorMessage,
+            ':created_at' => date('Y-m-d H:i:s'),
+        ]);
     }
 
     /** Aggregate global stats since the given date */

--- a/database/migrations/20250811_add_ringover_fields_to_calls.sql
+++ b/database/migrations/20250811_add_ringover_fields_to_calls.sql
@@ -1,0 +1,19 @@
+ALTER TABLE calls
+    ADD COLUMN call_id VARCHAR(255),
+    ADD COLUMN contact_number VARCHAR(50),
+    ADD COLUMN caller_name VARCHAR(255),
+    ADD COLUMN contact_name VARCHAR(255),
+    ADD COLUMN voicemail_url TEXT,
+    ADD COLUMN start_time TIMESTAMP NULL,
+    ADD COLUMN total_duration INT,
+    ADD COLUMN incall_duration INT;
+
+CREATE INDEX calls_call_id_idx ON calls(call_id);
+CREATE INDEX calls_start_time_idx ON calls(start_time);
+
+CREATE TABLE crm_sync_logs (
+    call_id INT NOT NULL,
+    result VARCHAR(20) NOT NULL,
+    error_message TEXT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add migration for ringover call fields and crm sync logs
- track CRM sync attempts in CallRepository
- support new call attributes in model and repository tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6899cafbc540832aa14d0abd6f3c88b0