### PR TITLE
Implement CRM sync workflow with Pipedrive

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -195,7 +195,8 @@ private function registerServices(): void
     $this->container->singleton(
         \FlujosDimension\Services\CRMService::class,
         fn ($c) => new \FlujosDimension\Services\CRMService(
-            $c->resolve(\FlujosDimension\Infrastructure\Http\PipedriveClient::class)
+            $c->resolve(\FlujosDimension\Infrastructure\Http\PipedriveClient::class),
+            $c->resolve('callRepository')
         )
     );
     $this->container->alias(\FlujosDimension\Services\CRMService::class, \FlujosDimension\Services\PipedriveService::class);

--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -311,7 +311,7 @@ class Database
                     ai_summary TEXT,
                     ai_keywords TEXT,
                     ai_sentiment ENUM('positive', 'negative', 'neutral') DEFAULT 'neutral',
-                    pipedrive_contact_id INT,
+                    pipedrive_person_id INT,
                     pipedrive_deal_id INT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -22,7 +22,7 @@ class Call extends BaseModel
         'caller_name', 'contact_name', 'direction', 'status', 'duration',
         'recording_url', 'voicemail_url', 'start_time', 'total_duration',
         'incall_duration', 'ai_transcription', 'ai_summary', 'ai_keywords',
-        'ai_sentiment', 'pipedrive_contact_id', 'pipedrive_deal_id'
+        'ai_sentiment', 'pipedrive_person_id', 'pipedrive_deal_id'
     ];
 
     protected array $casts = [
@@ -30,7 +30,7 @@ class Call extends BaseModel
         'duration' => 'int',
         'total_duration' => 'int',
         'incall_duration' => 'int',
-        'pipedrive_contact_id' => 'int',
+        'pipedrive_person_id' => 'int',
         'pipedrive_deal_id' => 'int',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
@@ -362,7 +362,7 @@ class Call extends BaseModel
     public function linkToPipedrive(int $id, int $contactId): bool
     {
         $sql = "UPDATE {$this->table} 
-                SET pipedrive_contact_id = :contact_id, updated_at = NOW() 
+                SET pipedrive_person_id = :contact_id, updated_at = NOW()
                 WHERE id = :id";
         
         $stmt = $this->database->prepare($sql);

--- a/app/Repositories/CallRepository.php
+++ b/app/Repositories/CallRepository.php
@@ -120,6 +120,28 @@ final class CallRepository
         return (int)$stmt->rowCount();
     }
 
+    /** Fetch a call by its primary ID. */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM calls WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /** Update Pipedrive identifiers for a call. */
+    public function updatePipedriveIds(int $id, ?int $personId, int $dealId): void
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE calls SET pipedrive_person_id = :pid, pipedrive_deal_id = :did, crm_synced = 1 WHERE id = :id'
+        );
+        $stmt->execute([
+            ':pid' => $personId,
+            ':did' => $dealId,
+            ':id'  => $id,
+        ]);
+    }
+
     /**
      * Retrieve the internal ID for a given Ringover ID.
      */

--- a/app/Services/CRMService.php
+++ b/app/Services/CRMService.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 namespace FlujosDimension\Services;
 
 use FlujosDimension\Infrastructure\Http\PipedriveClient;
+use FlujosDimension\Repositories\CallRepository;
+use RuntimeException;
 
 /**
  * Domain service wrapping Pipedrive operations.
  */
 class CRMService
 {
-    public function __construct(private readonly PipedriveClient $client) {}
+    public function __construct(
+        private readonly PipedriveClient $client,
+        private readonly ?CallRepository $calls = null
+    ) {}
 
     public function findPersonByPhone(string $phone, ?string $batchId = null, ?string $correlationId = null): ?int
     {
@@ -26,5 +31,79 @@ class CRMService
     public function createOrUpdateDeal(array $payload, ?string $batchId = null, ?string $correlationId = null): int
     {
         return $this->client->createOrUpdateDeal($payload, $batchId, $correlationId);
+    }
+
+    /**
+     * Sync a call with the CRM.
+     *
+     * @return int|null Deal ID on success, null on failure
+     */
+    public function sync(int $callId, ?string $batchId = null, ?string $correlationId = null): ?int
+    {
+        $correlationId ??= bin2hex(random_bytes(16));
+
+        if ($this->calls === null) {
+            throw new RuntimeException('CallRepository not configured');
+        }
+
+        $call = $this->calls->find($callId);
+        if (!$call) {
+            $this->calls->logCrmSync($callId, 'error', 'call_not_found', $batchId, $correlationId);
+            return null;
+        }
+
+        $phone    = $call['phone_number'] ?? null;
+        $personId = $call['pipedrive_person_id'] ?? null;
+        $dealId   = $call['pipedrive_deal_id'] ?? null;
+
+        try {
+            if ($personId === null && $phone) {
+                $personId = $this->findPersonByPhone($phone, $batchId, $correlationId);
+            }
+
+            if ($dealId === null) {
+                $dealId = $this->findOpenDeal((string)$callId, $phone, $batchId, $correlationId);
+            }
+
+            $fields = require dirname(__DIR__, 2) . '/config/pipedrive.php';
+            $custom = [
+                $fields['call_id_field'] => $callId,
+            ];
+            if (!empty($call['ai_sentiment'])) {
+                $custom[$fields['sentiment_field']] = $call['ai_sentiment'];
+            }
+            if (!empty($call['ai_summary'])) {
+                $custom[$fields['summary_field']] = $call['ai_summary'];
+            }
+            if (!empty($call['ai_transcription'])) {
+                $custom[$fields['transcript_field']] = $call['ai_transcription'];
+            }
+            if (!empty($call['recording_url'])) {
+                $custom[$fields['recording_field']] = $call['recording_url'];
+            }
+            if (!empty($call['duration'])) {
+                $custom[$fields['duration_field']] = $call['duration'];
+            }
+
+            $payload = [
+                'title'        => 'Call ' . $callId,
+                'value'        => 0,
+                'person_id'    => $personId,
+                'custom_fields'=> $custom,
+            ];
+            if ($dealId !== null) {
+                $payload['id'] = $dealId;
+            }
+
+            $dealId = $this->createOrUpdateDeal($payload, $batchId, $correlationId);
+
+            $this->calls->updatePipedriveIds($callId, $personId, $dealId);
+            $this->calls->logCrmSync($callId, 'success', null, $batchId, $correlationId);
+
+            return $dealId;
+        } catch (\Throwable $e) {
+            $this->calls->logCrmSync($callId, 'error', $e->getMessage(), $batchId, $correlationId);
+            return null;
+        }
     }
 }

--- a/config/pipedrive.php
+++ b/config/pipedrive.php
@@ -1,0 +1,10 @@
+<?php
+return [
+    // Pipedrive custom field keys for deals
+    'call_id_field'    => 'Call_ID',
+    'sentiment_field'  => 'Sentiment',
+    'summary_field'    => 'Summary',
+    'transcript_field' => 'Transcript',
+    'recording_field'  => 'Recording_URL',
+    'duration_field'   => 'Call_Duration',
+];

--- a/database/flujo_dimen_db20250810.sql
+++ b/database/flujo_dimen_db20250810.sql
@@ -251,7 +251,7 @@ CREATE TABLE `calls` (
   `ai_summary` text DEFAULT NULL,
   `ai_keywords` text DEFAULT NULL,
   `ai_sentiment` enum('positive','negative','neutral') DEFAULT 'neutral',
-  `pipedrive_contact_id` int(11) DEFAULT NULL,
+  `pipedrive_person_id` int(11) DEFAULT NULL,
   `action_items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`action_items`)),
   `call_quality_score` decimal(4,3) DEFAULT NULL,
   `customer_satisfaction_score` decimal(4,3) DEFAULT NULL,

--- a/tests/CRMServiceTest.php
+++ b/tests/CRMServiceTest.php
@@ -10,6 +10,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use PDO;
+use FlujosDimension\Repositories\CallRepository;
 
 class CRMServiceTest extends TestCase
 {
@@ -77,5 +79,65 @@ class CRMServiceTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $service->createOrUpdateDeal(['title' => 'Deal']);
+    }
+
+    public function testSyncCreatesDealAndLogs(): void
+    {
+        $mock = new MockHandler([
+            // findPersonByPhone
+            new Response(200, [], json_encode(['data' => ['items' => [['item' => ['id' => 5]]]]])),
+            // findOpenDeal by call ID
+            new Response(200, [], json_encode(['data' => ['items' => []]])),
+            // findOpenDeal by phone
+            new Response(200, [], json_encode(['data' => ['items' => []]])),
+            // createOrUpdateDeal
+            new Response(201, [], json_encode(['data' => ['id' => 7]])),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $http = new HttpClient(['handler' => $stack]);
+        $client  = new PipedriveClient($http, 't');
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            phone_number TEXT,
+            ai_summary TEXT,
+            ai_sentiment TEXT,
+            ai_transcription TEXT,
+            recording_url TEXT,
+            duration INTEGER,
+            pipedrive_person_id INTEGER,
+            pipedrive_deal_id INTEGER,
+            crm_synced INTEGER DEFAULT 0
+        );");
+        $pdo->exec("INSERT INTO calls (id, phone_number, ai_summary, ai_sentiment, ai_transcription, recording_url, duration)
+            VALUES (1,'123','s','pos','t','http://r',30)");
+        $pdo->exec("CREATE TABLE crm_sync_logs (
+            call_id INTEGER,
+            result TEXT,
+            error_message TEXT,
+            batch_id TEXT,
+            correlation_id TEXT,
+            created_at TEXT
+        );");
+
+        $repo = new CallRepository($pdo);
+        $service = new CRMService($client, $repo);
+
+        $dealId = $service->sync(1, 'batch-a', 'corr-a');
+
+        $this->assertSame(7, $dealId);
+        $row = $pdo->query('SELECT pipedrive_person_id, pipedrive_deal_id, crm_synced FROM calls WHERE id=1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(5, (int)$row['pipedrive_person_id']);
+        $this->assertSame(7, (int)$row['pipedrive_deal_id']);
+        $this->assertSame(1, (int)$row['crm_synced']);
+        $log = $pdo->query('SELECT result, batch_id, correlation_id FROM crm_sync_logs')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('success', $log['result']);
+        $this->assertSame('batch-a', $log['batch_id']);
+        $this->assertSame('corr-a', $log['correlation_id']);
+        $this->assertCount(4, $history);
     }
 }

--- a/tests/CallModelTest.php
+++ b/tests/CallModelTest.php
@@ -27,7 +27,7 @@ class CallModelTest extends TestCase
                 ai_summary TEXT,
                 ai_keywords TEXT,
                 ai_sentiment TEXT,
-                pipedrive_contact_id INTEGER,
+                pipedrive_person_id INTEGER,
                 pipedrive_deal_id INTEGER,
                 created_at TEXT,
                 updated_at TEXT
@@ -49,7 +49,7 @@ class CallModelTest extends TestCase
             'direction' => 'inbound',
             'status' => 'answered',
             'duration' => 30,
-            'pipedrive_contact_id' => 11,
+            'pipedrive_person_id' => 11,
             'pipedrive_deal_id' => 22
         ]);
 

--- a/tests/OrderBySanitizationTest.php
+++ b/tests/OrderBySanitizationTest.php
@@ -29,7 +29,7 @@ class OrderBySanitizationTest extends TestCase
             ai_summary TEXT,
             ai_keywords TEXT,
             ai_sentiment TEXT,
-            pipedrive_contact_id INTEGER,
+            pipedrive_person_id INTEGER,
             pipedrive_deal_id INTEGER,
             created_at TEXT,
             updated_at TEXT


### PR DESCRIPTION
## Summary
- add `config/pipedrive.php` with custom field keys for Pipedrive deals
- expand CRM service to sync calls: search person, upsert deal, update custom fields and log results
- expose repository helpers for fetching calls and updating Pipedrive IDs

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_6899d8c02130832a9535c9d67913ab22