### PR TITLE
Add API monitoring metadata and health dashboard

### DIFF
--- a/admin/health.php
+++ b/admin/health.php
@@ -1,0 +1,89 @@
+<?php
+// Simple health dashboard for API monitoring statistics
+// Requires admin login
+
+define('ADMIN_ACCESS', true);
+require_once __DIR__ . '/auth.php';
+requireLogin();
+
+// Load environment variables (same approach as admin/index.php)
+$envFile = dirname(__DIR__) . '/.env';
+if (file_exists($envFile)) {
+    foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        if ($line && $line[0] !== '#') {
+            [$k, $v] = explode('=', $line, 2);
+            $_ENV[trim($k)] = trim($v);
+        }
+    }
+}
+
+$requiredEnv = ['DB_HOST','DB_PORT','DB_NAME','DB_USER','DB_PASS'];
+foreach ($requiredEnv as $key) {
+    if (empty($_ENV[$key])) {
+        http_response_code(500);
+        die("Missing environment variable $key");
+    }
+}
+
+$dsn = sprintf(
+    'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+    $_ENV['DB_HOST'],
+    $_ENV['DB_PORT'],
+    $_ENV['DB_NAME']
+);
+$pdo = new PDO($dsn, $_ENV['DB_USER'], $_ENV['DB_PASS'], [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
+]);
+
+// Gather metrics for the last hour per service
+$sql = "SELECT service,
+               AVG(response_time) AS avg_latency,
+               PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_time) AS p95_latency,
+               SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) / COUNT(*) * 100 AS error_rate
+        FROM api_monitoring
+        WHERE timestamp >= NOW() - INTERVAL 1 HOUR
+        GROUP BY service";
+$metrics = $pdo->query($sql)->fetchAll();
+
+$errorThreshold = 5;      // %
+$latencyThreshold = 2000; // ms
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Panel de Salud</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }
+        th { background: #f0f0f0; }
+        .alert { background: #fdd; }
+    </style>
+</head>
+<body>
+<h1>Panel de Salud de APIs</h1>
+<table>
+    <tr>
+        <th>Servicio</th>
+        <th>Latencia media (ms)</th>
+        <th>P95 (ms)</th>
+        <th>Tasa de errores (%)</th>
+    </tr>
+    <?php foreach ($metrics as $row):
+        $alert = ($row['error_rate'] > $errorThreshold) || ($row['p95_latency'] > $latencyThreshold);
+        if ($alert) {
+            error_log('api_health_alert: ' . json_encode($row));
+        }
+    ?>
+    <tr class="<?php echo $alert ? 'alert' : ''; ?>">
+        <td><?php echo htmlspecialchars($row['service']); ?></td>
+        <td><?php echo round((float)$row['avg_latency'], 2); ?></td>
+        <td><?php echo round((float)$row['p95_latency'], 2); ?></td>
+        <td><?php echo round((float)$row['error_rate'], 2); ?></td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+</body>
+</html>

--- a/app/Infrastructure/Http/OpenAIClient.php
+++ b/app/Infrastructure/Http/OpenAIClient.php
@@ -36,7 +36,7 @@ final class OpenAIClient
                 'Content-Type'  => 'application/json',
             ],
             'json' => ['model' => $this->model, 'messages' => $messages] + $extra,
-            'api_name'       => 'OpenAI',
+            'service'        => 'OpenAI',
             'batch_id'       => $batchId,
             'correlation_id' => $correlationId,
         ]);

--- a/app/Infrastructure/Http/PipedriveClient.php
+++ b/app/Infrastructure/Http/PipedriveClient.php
@@ -26,7 +26,7 @@ final class PipedriveClient
                 'fields'    => 'phone',
                 'api_token' => $this->token,
             ],
-            'api_name'       => 'Pipedrive',
+            'service'        => 'Pipedrive',
             'batch_id'       => $batchId,
             'correlation_id' => $correlationId,
         ]);
@@ -48,7 +48,7 @@ final class PipedriveClient
                 'status'    => 'open',
                 'api_token' => $this->token,
             ],
-            'api_name'       => 'Pipedrive',
+            'service'        => 'Pipedrive',
             'batch_id'       => $batchId,
             'correlation_id' => $correlationId,
         ]);
@@ -74,7 +74,7 @@ final class PipedriveClient
                 'status'    => 'open',
                 'api_token' => $this->token,
             ],
-            'api_name'       => 'Pipedrive',
+            'service'        => 'Pipedrive',
             'batch_id'       => $batchId,
             'correlation_id' => $correlationId,
         ]);
@@ -95,7 +95,7 @@ final class PipedriveClient
         $resp = $this->http->request('POST', self::BASE . '/deals', [
             'query' => ['api_token' => $this->token],
             'json'  => $payload,
-            'api_name'       => 'Pipedrive',
+            'service'        => 'Pipedrive',
             'batch_id'       => $batchId,
             'correlation_id' => $correlationId,
         ]);

--- a/app/Infrastructure/Http/RingoverClient.php
+++ b/app/Infrastructure/Http/RingoverClient.php
@@ -52,7 +52,7 @@ final class RingoverClient
                     'start_date' => $since->format(DATE_ATOM),
                     'limit'      => 1,
                 ],
-                'api_name' => 'Ringover',
+                'service' => 'Ringover',
             ]);
             $code = $resp->getStatusCode();
             if ($code >= 200 && $code < 300) {
@@ -83,7 +83,7 @@ final class RingoverClient
                 'query'           => $query,
                 'timeout'         => 10,
                 'connect_timeout' => 5,
-                'api_name'        => 'Ringover',
+                'service'        => 'Ringover',
                 'batch_id'        => $batchId,
                 'correlation_id'  => $correlationId,
             ]);
@@ -181,7 +181,7 @@ final class RingoverClient
         $options = [
             'headers'         => ['Authorization' => $this->apiKey],
             'allow_redirects' => ['max' => 5, 'track_redirects' => true],
-            'api_name'        => 'Ringover',
+            'service'        => 'Ringover',
             'batch_id'        => $batchId,
             'correlation_id'  => $correlationId,
         ];
@@ -190,7 +190,7 @@ final class RingoverClient
         if (in_array($head->getStatusCode(), [401, 403], true)) {
             $head = $this->http->request('HEAD', $url, [
                 'allow_redirects' => ['max' => 5, 'track_redirects' => true],
-                'api_name'        => 'Ringover',
+                'service'        => 'Ringover',
                 'batch_id'        => $batchId,
                 'correlation_id'  => $correlationId,
             ]);
@@ -240,7 +240,7 @@ final class RingoverClient
         if (in_array($resp->getStatusCode(), [401, 403], true)) {
             $resp = $this->http->request('GET', $url, [
                 'allow_redirects' => ['max' => 5, 'track_redirects' => true],
-                'api_name'        => 'Ringover',
+                'service'        => 'Ringover',
                 'batch_id'        => $batchId,
                 'correlation_id'  => $correlationId,
             ]);

--- a/database/flujo_dimen_db20250810.sql
+++ b/database/flujo_dimen_db20250810.sql
@@ -86,11 +86,13 @@ CREATE TABLE `api_configurations` (
 
 CREATE TABLE `api_monitoring` (
   `id` int(11) NOT NULL,
-  `api_name` varchar(100) NOT NULL,
-  `endpoint` varchar(255) NOT NULL,
+  `service` varchar(100) NOT NULL,
+  `request_path` varchar(255) NOT NULL,
+  `method` varchar(10) NOT NULL,
   `response_time` int(11) NOT NULL,
   `status_code` int(11) NOT NULL,
   `success` tinyint(1) NOT NULL,
+  `correlation_id` varchar(255) DEFAULT NULL,
   `error_message` text DEFAULT NULL,
   `timestamp` timestamp NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -99,10 +101,10 @@ CREATE TABLE `api_monitoring` (
 -- Volcado de datos para la tabla `api_monitoring`
 --
 
-INSERT INTO `api_monitoring` (`id`, `api_name`, `endpoint`, `response_time`, `status_code`, `success`, `error_message`, `timestamp`) VALUES
-(1, 'Ringover', '/v2/calls', 372, 200, 1, NULL, '2025-07-18 10:37:50'),
-(2, 'OpenAI', '/v1/models', 424, 200, 1, NULL, '2025-07-18 10:37:50'),
-(3, 'Pipedrive', '/v1/users', 187, 200, 1, NULL, '2025-07-18 10:37:50');
+INSERT INTO `api_monitoring` (`id`, `service`, `request_path`, `method`, `response_time`, `status_code`, `success`, `correlation_id`, `error_message`, `timestamp`) VALUES
+(1, 'Ringover', '/v2/calls', 'GET', 372, 200, 1, NULL, NULL, '2025-07-18 10:37:50'),
+(2, 'OpenAI', '/v1/models', 'GET', 424, 200, 1, NULL, NULL, '2025-07-18 10:37:50'),
+(3, 'Pipedrive', '/v1/users', 'GET', 187, 200, 1, NULL, NULL, '2025-07-18 10:37:50');
 
 -- --------------------------------------------------------
 
@@ -818,7 +820,7 @@ ALTER TABLE `api_configurations`
 --
 ALTER TABLE `api_monitoring`
   ADD PRIMARY KEY (`id`),
-  ADD KEY `idx_api_timestamp` (`api_name`,`timestamp`),
+  ADD KEY `idx_service_timestamp` (`service`,`timestamp`),
   ADD KEY `idx_success_timestamp` (`success`,`timestamp`);
 
 --


### PR DESCRIPTION
## Summary
- store request_path, method, correlation_id and service for each API call
- log monitoring data from HttpClient and clients
- add admin health dashboard with latency, p95 and error rate alerts

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a074b8fe4832a8af337dcc7edaa85