### PR TITLE
Configure PHPUnit coverage and CI coverage driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+      - name: Run tests
+        run: vendor/bin/phpunit --coverage-text

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,14 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <include>
+            <directory>app</directory>
+        </include>
+        <exclude>
+            <directory>tests</directory>
+        </exclude>
+    </coverage>
     <php>
         <env name="DB_HOST" value="localhost"/>
         <env name="DB_NAME" value="testdb"/>


### PR DESCRIPTION
## Summary
- enable PHPUnit code coverage filtering
- add GitHub Actions CI workflow using xdebug coverage driver

## Testing
- `phpdbg -qrr vendor/bin/phpunit --coverage-text`


------
https://chatgpt.com/codex/tasks/task_e_689a2eb79990832a893ae1c4234df11a