### PR TITLE
Add Ringover fixtures and comprehensive tests with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Run tests
+        run: vendor/bin/phpunit --coverage-text

--- a/tests/DTOValidationTest.php
+++ b/tests/DTOValidationTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\DTO\CallMetadataDTO;
+use FlujosDimension\DTO\TranscriptionDTO;
+use FlujosDimension\Support\Validator;
+
+class DTOValidationTest extends TestCase
+{
+    public function testCallMetadataDtoValidates(): void
+    {
+        $dto = new CallMetadataDTO('123', 'inbound', 'answered', 30);
+        $errors = Validator::validate($dto->toArray(), [
+            'phone_number' => 'required|string',
+            'direction'    => 'required|in:inbound,outbound',
+            'status'       => 'required|string',
+            'duration'     => 'integer',
+        ]);
+        $this->assertSame([], $errors);
+    }
+
+    public function testTranscriptionDtoRejectsInvalidData(): void
+    {
+        $errors = Validator::validate(['call_id' => 1], [
+            'call_id' => 'required|integer',
+            'text'    => 'required|string',
+        ]);
+        $this->assertArrayHasKey('text', $errors);
+    }
+}

--- a/tests/HttpClientRetryTest.php
+++ b/tests/HttpClientRetryTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+
+class HttpClientRetryTest extends TestCase
+{
+    public function testRetriesOnServerError(): void
+    {
+        $mock = new MockHandler([
+            new Response(500),
+            new Response(200, [], 'ok'),
+        ]);
+        $history = [];
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+        $client = new HttpClient(['handler' => $stack], 5, 1);
+
+        $resp = $client->request('GET', 'https://example.com');
+
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertCount(2, $history);
+    }
+}

--- a/tests/IntegrationFlowTest.php
+++ b/tests/IntegrationFlowTest.php
@@ -2,15 +2,83 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
+use FlujosDimension\Services\CallService;
+use FlujosDimension\Services\CRMService;
+use FlujosDimension\Infrastructure\Http\RingoverClient;
+use FlujosDimension\Infrastructure\Http\PipedriveClient;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+use FlujosDimension\Core\Config;
+use FlujosDimension\Repositories\CallRepository;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PDO;
 
 class IntegrationFlowTest extends TestCase
 {
-    public function testEndToEndFlow()
+    public function testEndToEndFlow(): void
     {
-        if (!getenv('RUN_INTEGRATION_TESTS')) {
-            $this->markTestSkipped('Integration tests are disabled');
-        }
+        $call = json_decode(file_get_contents(__DIR__ . '/fixtures/ringover_call.json'), true);
 
-        $this->assertTrue(true);
+        // Ringover mock
+        $ringoverMock = new MockHandler([
+            new Response(200, [], json_encode([
+                'call_list' => [$call],
+                'call_list_count' => 1,
+                'total_call_count' => 1,
+            ])),
+            new Response(200, ['Content-Length' => 5, 'X-Recording-Duration' => 30, 'X-Guzzle-Effective-Url' => 'https://files.test/call.mp3']),
+            new Response(200, [], 'audio'),
+        ]);
+        $ringoverStack = HandlerStack::create($ringoverMock);
+        $ringoverHttp = new HttpClient(['handler' => $ringoverStack]);
+        $config = Config::getInstance();
+        $config->set('RINGOVER_API_KEY', 't');
+        $config->set('RINGOVER_API_URL', 'https://api.test');
+        $ringoverClient = new RingoverClient($ringoverHttp, $config);
+        $callService = new CallService($ringoverClient);
+
+        // CRM mock
+        $crmMock = new MockHandler([
+            new Response(200, [], json_encode(['data' => ['items' => [['item' => ['id' => 5]]]]])),
+            new Response(200, [], json_encode(['data' => ['items' => []]])),
+            new Response(200, [], json_encode(['data' => ['items' => []]])),
+            new Response(201, [], json_encode(['data' => ['id' => 7]])),
+        ]);
+        $crmStack = HandlerStack::create($crmMock);
+        $crmHttp = new HttpClient(['handler' => $crmStack]);
+        $crmClient = new PipedriveClient($crmHttp, 'token');
+
+        // DB setup
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE calls (id INTEGER PRIMARY KEY AUTOINCREMENT, ringover_id TEXT, call_id TEXT, phone_number TEXT, contact_number TEXT, caller_name TEXT, contact_name TEXT, direction TEXT, status TEXT, duration INTEGER, recording_url TEXT, recording_path TEXT, has_recording INTEGER DEFAULT 0, voicemail_url TEXT, start_time TEXT, total_duration INTEGER, incall_duration INTEGER, created_at TEXT, correlation_id TEXT, batch_id TEXT, ai_transcription TEXT, pipedrive_person_id INTEGER, pipedrive_deal_id INTEGER, crm_synced INTEGER DEFAULT 0);");
+        $pdo->exec("CREATE TABLE call_recordings (call_id INTEGER, file_path TEXT, file_size INTEGER, duration INTEGER, format TEXT);");
+        $pdo->exec("CREATE TABLE crm_sync_logs (call_id INTEGER, result TEXT, error_message TEXT, batch_id TEXT, correlation_id TEXT, created_at TEXT);");
+        $repo = new CallRepository($pdo);
+        $crmService = new CRMService($crmClient, $repo);
+
+        // Import
+        $calls = iterator_to_array($callService->getCalls(new \DateTimeImmutable('2024-03-01T00:00:00Z')));
+        $this->assertCount(1, $calls);
+        $repo->insertOrIgnore($calls[0]);
+        $id = (int)$pdo->query('SELECT id FROM calls')->fetchColumn();
+        $this->assertSame(1, $id);
+
+        // Download
+        $info = $callService->downloadRecording($calls[0]['recording_url'], sys_get_temp_dir());
+        $repo->addRecording($id, $info);
+
+        // Transcription simulated
+        $pdo->exec("UPDATE calls SET ai_transcription='transcribed', duration={$info['duration']} WHERE id={$id}");
+
+        // CRM
+        $dealId = $crmService->sync($id);
+        $this->assertSame(7, $dealId);
+        $row = $pdo->query('SELECT crm_synced, pipedrive_deal_id FROM calls WHERE id=1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(1, (int)$row['crm_synced']);
+        $this->assertSame(7, (int)$row['pipedrive_deal_id']);
+
+        @unlink($info['path']);
     }
 }

--- a/tests/MapCallFieldsFixtureTest.php
+++ b/tests/MapCallFieldsFixtureTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Services\CallService;
+use FlujosDimension\Infrastructure\Http\RingoverClient;
+use FlujosDimension\Infrastructure\Http\HttpClient;
+use FlujosDimension\Core\Config;
+
+class MapCallFieldsFixtureTest extends TestCase
+{
+    public function testMappingWithFixture(): void
+    {
+        $call = json_decode(file_get_contents(__DIR__ . '/fixtures/ringover_call.json'), true);
+
+        $config = Config::getInstance();
+        $config->set('RINGOVER_API_KEY', 'test');
+        $client = new RingoverClient(new HttpClient(), $config);
+        $service = new CallService($client);
+
+        $mapped = $service->mapCallFields($call);
+
+        $this->assertSame('abc123', $mapped['ringover_id']);
+        $this->assertSame('call-xyz', $mapped['call_id']);
+        $this->assertSame('+1234567890', $mapped['phone_number']);
+        $this->assertSame('Alice', $mapped['caller_name']);
+        $this->assertSame('Bob', $mapped['contact_name']);
+        $this->assertSame('inbound', $mapped['direction']);
+        $this->assertSame('answered', $mapped['status']);
+        $this->assertSame(30, $mapped['duration']);
+        $this->assertSame('https://files.test/call.mp3', $mapped['recording_url']);
+    }
+}

--- a/tests/fixtures/ringover_call.json
+++ b/tests/fixtures/ringover_call.json
@@ -1,0 +1,12 @@
+{
+  "cdr_id": "abc123",
+  "call_id": "call-xyz",
+  "from_number": "+1234567890",
+  "from_name": "Alice",
+  "to_name": "Bob",
+  "direction": "in",
+  "last_state": "answered",
+  "incall_duration": 30,
+  "record": "https://files.test/call.mp3",
+  "call_start": "2024-03-01T00:00:00Z"
+}


### PR DESCRIPTION
## Summary
- add Ringover call fixtures and unit tests for mapping, DTO validation and HTTP retries
- implement end-to-end integration flow test with mocked clients
- configure GitHub Actions to run test suite on push and PRs

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpunit --coverage-text` *(no code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_689a18fa630c832a91624c8c1559ebed