### PR TITLE
Fix test warnings and migrate PHPUnit config

### DIFF
--- a/admin/api/sync_ringover.php
+++ b/admin/api/sync_ringover.php
@@ -8,9 +8,15 @@ use FlujosDimension\Repositories\CallRepository;
 use FlujosDimension\Core\Request;
 
 // Configuración de niveles de log
-define('LOG_LEVEL_DEBUG', 0);
-define('LOG_LEVEL_INFO', 1);
-define('LOG_LEVEL_ERROR', 2);
+if (!defined('LOG_LEVEL_DEBUG')) {
+    define('LOG_LEVEL_DEBUG', 0);
+}
+if (!defined('LOG_LEVEL_INFO')) {
+    define('LOG_LEVEL_INFO', 1);
+}
+if (!defined('LOG_LEVEL_ERROR')) {
+    define('LOG_LEVEL_ERROR', 2);
+}
 
 // Inicializa el log
 $logDir = dirname(__DIR__, 2) . '/storage/logs';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory>app</directory>
-        </include>
-        <exclude>
-            <directory>tests</directory>
-        </exclude>
-    </coverage>
-    <php>
-        <env name="DB_HOST" value="localhost"/>
-        <env name="DB_NAME" value="testdb"/>
-        <env name="DB_USER" value="user"/>
-        <env name="DB_PASS" value="pass"/>
-        <env name="ADMIN_USER" value="admin"/>
-        <env name="ADMIN_PASS" value="secret"/>
-        <env name="JWT_SECRET" value="key"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DB_HOST" value="localhost"/>
+    <env name="DB_NAME" value="testdb"/>
+    <env name="DB_USER" value="user"/>
+    <env name="DB_PASS" value="pass"/>
+    <env name="ADMIN_USER" value="admin"/>
+    <env name="ADMIN_PASS" value="secret"/>
+    <env name="JWT_SECRET" value="key"/>
+  </php>
+  <source>
+    <include>
+      <directory>app</directory>
+    </include>
+    <exclude>
+      <directory>tests</directory>
+    </exclude>
+  </source>
 </phpunit>


### PR DESCRIPTION
## Summary
- Prevent log level constants from redeclaration during tests
- Migrate PHPUnit XML config to current schema

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a5a17f7e0832aa2366b81f098b52e