### PR TITLE
Refactor Ringover service usage, standardize sync response and add JWT key rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,9 @@ PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_API_TOKEN=your-pipedrive-token
 
 # Security
-JWT_SECRET=change-me
+JWT_KID=v1
+JWT_KEYS_CURRENT=change-me-current
+JWT_KEYS_PREVIOUS=
 ADMIN_USER=admin
 # password_hash('password', PASSWORD_DEFAULT)
 ADMIN_PASS=$2y$12$96juvNB1AHHxmijQPKVz5.J9CrsDdgIYY9cA2LY.Qbv.4XxYBT.Cu

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer install
 cp .env.example .env
 # Edit `.env` and set database values (`DB_HOST`, `DB_PORT`, `DB_NAME`,
 # `DB_USER`, `DB_PASS`) plus `RINGOVER_API_KEY`, `PIPEDRIVE_API_TOKEN`,
-# `OPENAI_API_KEY` and `JWT_SECRET`. The variable
+# `OPENAI_API_KEY` and JWT keys (`JWT_KID`, `JWT_KEYS_CURRENT`, `JWT_KEYS_PREVIOUS`). The variable
 # `RINGOVER_MAX_RECORDING_MB` limits the size of downloaded
 # recordings (default 100).
 mkdir -p storage/recordings storage/voicemails

--- a/admin/views/env_editor.php
+++ b/admin/views/env_editor.php
@@ -236,7 +236,7 @@
             $configStatus = [
                 'Base de Datos' => !empty($this->config->get('DB_HOST')) && !empty($this->config->get('DB_NAME')),
                 'Administrador' => !empty($this->config->get('ADMIN_USER')) && !empty($this->config->get('ADMIN_PASS')),
-                'JWT Secret' => !empty($this->config->get('JWT_SECRET')),
+                'JWT Keys' => !empty($this->config->get('JWT_KEYS_CURRENT')),
                 'API Ringover' => !empty($this->config->get('RINGOVER_API_KEY')),
                 'API OpenAI' => !empty($this->config->get('OPENAI_API_KEY')),
                 'API Pipedrive' => !empty($this->config->get('PIPEDRIVE_API_TOKEN'))
@@ -353,13 +353,20 @@
                 <div class="section-title">🔐 Seguridad y JWT</div>
                 <div class="form-row">
                     <div class="form-group">
-                          <label for="JWT_SECRET">Clave Secreta JWT</label>
-                          <input type="password" id="JWT_SECRET" name="JWT_SECRET" placeholder="********" required>
-                        <div class="help-text">Mínimo 32 caracteres para mayor seguridad</div>
+                        <label for="JWT_KID">JWT Key ID</label>
+                        <input type="text" id="JWT_KID" name="JWT_KID" value="<?php echo htmlspecialchars($this->config->get('JWT_KID', 'v1')); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="JWT_KEYS_CURRENT">Clave JWT actual</label>
+                        <input type="password" id="JWT_KEYS_CURRENT" name="JWT_KEYS_CURRENT" placeholder="********" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="JWT_KEYS_PREVIOUS">Claves JWT previas</label>
+                        <input type="text" id="JWT_KEYS_PREVIOUS" name="JWT_KEYS_PREVIOUS" placeholder="kid1:secret1,kid2:secret2">
                     </div>
                     <div class="form-group">
                         <label for="JWT_EXPIRATION_HOURS">Expiración JWT (horas)</label>
-                        <input type="number" id="JWT_EXPIRATION_HOURS" name="JWT_EXPIRATION_HOURS" 
+                        <input type="number" id="JWT_EXPIRATION_HOURS" name="JWT_EXPIRATION_HOURS"
                                value="<?php echo htmlspecialchars($this->config->get('JWT_EXPIRATION_HOURS', '24')); ?>" required>
                     </div>
                 </div>
@@ -428,17 +435,16 @@
             alert('Función de test de Pipedrive en desarrollo. Token configurado: ' + (token ? 'Sí' : 'No'));
         }
         
-        // Generar JWT Secret automáticamente si está vacío
+        // Generar clave JWT automáticamente si está vacía
         document.addEventListener('DOMContentLoaded', function() {
-            const jwtSecretField = document.getElementById('JWT_SECRET');
-            if (!jwtSecretField.value) {
-                // Generar una clave aleatoria de 64 caracteres
+            const jwtCurrentField = document.getElementById('JWT_KEYS_CURRENT');
+            if (!jwtCurrentField.value) {
                 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
                 let secret = '';
                 for (let i = 0; i < 64; i++) {
                     secret += chars.charAt(Math.floor(Math.random() * chars.length));
                 }
-                jwtSecretField.value = secret;
+                jwtCurrentField.value = secret;
             }
         });
     </script>

--- a/app/Console/SyncHourlyCommand.php
+++ b/app/Console/SyncHourlyCommand.php
@@ -2,7 +2,7 @@
 namespace FlujosDimension\Console;
 
 use FlujosDimension\Core\Application;
-use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Services\CallService;
 use FlujosDimension\Repositories\CallRepository;
 use FlujosDimension\Services\AnalyticsService;
 use Symfony\Component\Console\Command\Command;
@@ -33,13 +33,13 @@ class SyncHourlyCommand extends Command
         $container = $this->app->getContainer();
 
         try {
-            if (!$container->bound(RingoverService::class) || !$container->bound('callRepository')) {
+            if (!$container->bound(CallService::class) || !$container->bound('callRepository')) {
                 $output->writeln('<info>No services configured</info>');
                 return Command::SUCCESS;
             }
 
-            /** @var RingoverService $ringover */
-            $ringover = $container->resolve(RingoverService::class);
+            /** @var CallService $ringover */
+            $ringover = $container->resolve(CallService::class);
             /** @var CallRepository $repo */
             $repo     = $container->resolve('callRepository');
             /** @var AnalyticsService|null $analytics */

--- a/app/Controllers/ConfigController.php
+++ b/app/Controllers/ConfigController.php
@@ -22,7 +22,8 @@ class ConfigController extends BaseController
                 'RINGOVER_API_KEY',
                 'PIPEDRIVE_API_TOKEN',
                 'OPENAI_API_KEY',
-                'JWT_SECRET',
+                'JWT_KEYS_CURRENT',
+                'JWT_KEYS_PREVIOUS',
                 'DB_PASS',
             ];
             foreach ($sensitive as $key) {

--- a/app/Core/Config.php
+++ b/app/Core/Config.php
@@ -143,7 +143,7 @@ class Config
                 'API RINGOVER' => ['RINGOVER_API_URL', 'RINGOVER_API_KEY', 'RINGOVER_WEBHOOK_SECRET', 'RINGOVER_MAX_RECORDING_MB'],
                 'API OPENAI' => ['OPENAI_API_URL', 'OPENAI_API_KEY'],
                 'API PIPEDRIVE' => ['PIPEDRIVE_API_URL', 'PIPEDRIVE_API_TOKEN'],
-                'SEGURIDAD Y JWT' => ['JWT_SECRET', 'JWT_EXPIRATION_HOURS', 'APP_ENV', 'APP_DEBUG'],
+                'SEGURIDAD Y JWT' => ['JWT_KID', 'JWT_KEYS_CURRENT', 'JWT_KEYS_PREVIOUS', 'JWT_EXPIRATION_HOURS', 'APP_ENV', 'APP_DEBUG'],
                 'CONFIGURACIÓN DE API' => ['MAX_API_REQUESTS_PER_HOUR', 'API_TIMEOUT', 'API_LOG_LEVEL', 'RATE_LIMIT_ENABLED'],
                 'CONFIGURACIÓN DE SISTEMA' => ['TIMEZONE', 'LOG_RETENTION_DAYS', 'BACKUP_RETENTION_DAYS', 'MAX_UPLOAD_SIZE', 'CACHE_ENABLED', 'CACHE_TTL', 'SESSION_LIFETIME']
             ];
@@ -242,7 +242,9 @@ class Config
     public function getJwtConfig()
     {
         return [
-            'secret' => $this->get('JWT_SECRET', ''),
+            'current_key'   => $this->get('JWT_KEYS_CURRENT', $this->get('JWT_SECRET', '')),
+            'previous_keys' => $this->get('JWT_KEYS_PREVIOUS', ''),
+            'kid'           => $this->get('JWT_KID', 'default'),
             'expiration_hours' => (int)$this->get('JWT_EXPIRATION_HOURS', 24),
             'algorithm' => 'HS256'
         ];
@@ -256,7 +258,7 @@ class Config
         $required = [
             'DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASS',
             'ADMIN_USER', 'ADMIN_PASS',
-            'JWT_SECRET'
+            'JWT_KID', 'JWT_KEYS_CURRENT'
         ];
         
         $missing = [];

--- a/app/Core/JWT.php
+++ b/app/Core/JWT.php
@@ -10,26 +10,49 @@ namespace FlujosDimension\Core;
 
 use Exception;
 use PDO;
+use Firebase\JWT\JWT as FirebaseJWT;
+use Firebase\JWT\Key;
 class JWT
 {
-    private $secret;
-    private $algorithm;
-    private $expirationHours;
+    private string $currentKey;
+    /** @var array<string,string> */
+    private array $previousKeys;
+    private string $kid;
+    private string $algorithm;
+    private int $expirationHours;
     private PDO $pdo;
-    
+
     public function __construct(PDO $pdo)
     {
         $config = Config::getInstance();
         $jwtConfig = $config->getJwtConfig();
 
-        $this->secret = $jwtConfig['secret'];
-        $this->algorithm = $jwtConfig['algorithm'];
-        $this->expirationHours = $jwtConfig['expiration_hours'];
+        $this->currentKey   = (string)$jwtConfig['current_key'];
+        $this->previousKeys = $this->parseKeyList((string)$jwtConfig['previous_keys']);
+        $this->kid          = (string)$jwtConfig['kid'];
+        $this->algorithm    = $jwtConfig['algorithm'];
+        $this->expirationHours = (int)$jwtConfig['expiration_hours'];
         $this->pdo = $pdo;
-        
-        if (empty($this->secret)) {
-            throw new Exception("JWT secret not configured");
+
+        if (empty($this->currentKey)) {
+            throw new Exception('JWT current key not configured');
         }
+    }
+
+    /**
+     * Parse comma-separated list of kid:secret pairs.
+     * @return array<string,string>
+     */
+    private function parseKeyList(string $list): array
+    {
+        $keys = [];
+        foreach (array_filter(array_map('trim', explode(',', $list))) as $pair) {
+            [$k, $v] = array_map('trim', explode(':', $pair, 2));
+            if ($k !== '' && $v !== '') {
+                $keys[$k] = $v;
+            }
+        }
+        return $keys;
     }
     
     /**
@@ -37,31 +60,23 @@ class JWT
      */
     public function generateToken($payload = [])
     {
+        $now = time();
+        $jti = bin2hex(random_bytes(16));
+        $basePayload = [
+            'jti' => $jti,
+            'iat' => $now,
+            'nbf' => $now,
+            'exp' => $now + ($this->expirationHours * 3600),
+        ];
+        $payload = array_merge($basePayload, $payload);
         $header = [
             'typ' => 'JWT',
-            'alg' => $this->algorithm
+            'alg' => $this->algorithm,
+            'kid' => $this->kid,
         ];
-        
-        $now = time();
-        $defaultPayload = [
-            'iat' => $now, // Issued at
-            'exp' => $now + ($this->expirationHours * 3600), // Expiration
-            'iss' => 'flujos-dimension-v4.1', // Issuer
-            'sub' => 'api-access' // Subject
-        ];
-        
-        $payload = array_merge($defaultPayload, $payload);
-        
-        $headerEncoded = $this->base64UrlEncode(json_encode($header));
-        $payloadEncoded = $this->base64UrlEncode(json_encode($payload));
-        
-        $signature = $this->generateSignature($headerEncoded . '.' . $payloadEncoded);
-        
-        $token = $headerEncoded . '.' . $payloadEncoded . '.' . $signature;
-        
-        // Guardar token en base de datos
-        $this->saveTokenToDatabase($token, $payload['exp']);
-        
+
+        $token = FirebaseJWT::encode($payload, $this->currentKey, $this->algorithm, null, $header);
+        $this->saveTokenToDatabase($jti, $payload['exp']);
         return $token;
     }
     
@@ -72,44 +87,33 @@ class JWT
     {
         try {
             $parts = explode('.', $token);
-            
             if (count($parts) !== 3) {
                 return false;
             }
-            
-            list($headerEncoded, $payloadEncoded, $signature) = $parts;
-            
-            // Verificar firma
-            $expectedSignature = $this->generateSignature($headerEncoded . '.' . $payloadEncoded);
-            if (!hash_equals($signature, $expectedSignature)) {
+
+            $header = json_decode($this->base64UrlDecode($parts[0]), true);
+            $kid = $header['kid'] ?? '';
+            $key = $kid === $this->kid ? $this->currentKey : ($this->previousKeys[$kid] ?? null);
+            if ($key === null) {
                 return false;
             }
-            
-            // Decodificar payload
-            $payload = json_decode($this->base64UrlDecode($payloadEncoded), true);
-            
-            if (!$payload) {
-                return false;
-            }
-            
-            // Verificar expiración
+
+            $payload = (array) FirebaseJWT::decode($token, new Key($key, $this->algorithm));
+
             if (isset($payload['exp']) && $payload['exp'] < time()) {
-                $this->logInfo("Token expired for: " . ($payload['sub'] ?? 'unknown'));
+                $this->logInfo('Token expired');
                 return false;
             }
-            
-            // Verificar que el token existe en la base de datos y está activo
-            if (!$this->isTokenActiveInDatabase($token)) {
+
+            $jti = $payload['jti'] ?? null;
+            if (!$jti || !$this->isTokenActiveInDatabase($jti)) {
                 return false;
             }
-            
-            // Actualizar último uso
-            $this->updateTokenLastUsed($token);
-            
+
+            $this->updateTokenLastUsed($jti);
             return $payload;
-            
         } catch (Exception $e) {
-            $this->logError("Token validation error: " . $e->getMessage());
+            $this->logError('Token validation error: ' . $e->getMessage());
             return false;
         }
     }
@@ -120,23 +124,30 @@ class JWT
     public function revokeToken($token)
     {
         try {
-            $tokenHash = hash('sha256', $token);
-
+            $parts = explode('.', $token);
+            $header = json_decode($this->base64UrlDecode($parts[0] ?? ''), true);
+            $kid = $header['kid'] ?? '';
+            $key = $kid === $this->kid ? $this->currentKey : ($this->previousKeys[$kid] ?? null);
+            if ($key === null) {
+                return false;
+            }
+            $payload = (array) FirebaseJWT::decode($token, new Key($key, $this->algorithm));
+            $jti = $payload['jti'] ?? null;
+            if (!$jti) {
+                return false;
+            }
             $stmt = $this->pdo->prepare(
                 "UPDATE api_tokens SET is_active = FALSE WHERE token_hash = ?"
             );
-            $stmt->execute([$tokenHash]);
+            $stmt->execute([hash('sha256', $jti)]);
             $result = $stmt->rowCount();
-            
             if ($result > 0) {
-                $this->logInfo("Token revoked successfully");
+                $this->logInfo('Token revoked successfully');
                 return true;
             }
-            
             return false;
-            
         } catch (Exception $e) {
-            $this->logError("Error revoking token: " . $e->getMessage());
+            $this->logError('Error revoking token: ' . $e->getMessage());
             return false;
         }
     }
@@ -187,22 +198,6 @@ class JWT
     }
     
     /**
-     * Generar firma HMAC
-     */
-    private function generateSignature($data)
-    {
-        return $this->base64UrlEncode(hash_hmac('sha256', $data, $this->secret, true));
-    }
-    
-    /**
-     * Codificar en Base64 URL-safe
-     */
-    private function base64UrlEncode($data)
-    {
-        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
-    }
-    
-    /**
      * Decodificar Base64 URL-safe
      */
     private function base64UrlDecode($data)
@@ -213,43 +208,36 @@ class JWT
     /**
      * Guardar token en base de datos
      */
-    private function saveTokenToDatabase($token, $expiresAt)
+    private function saveTokenToDatabase(string $jti, int $expiresAt): void
     {
         try {
-            $tokenHash = hash('sha256', $token);
             $stmt = $this->pdo->prepare(
                 "INSERT INTO api_tokens (token_hash, name, expires_at) VALUES (?, ?, ?)"
             );
             $stmt->execute([
-                $tokenHash,
+                hash('sha256', $jti),
                 'API Access Token',
                 date('Y-m-d H:i:s', $expiresAt)
             ]);
-            
-            $this->logInfo("Token saved to database successfully");
-            
+            $this->logInfo('Token saved to database successfully');
         } catch (Exception $e) {
-            $this->logError("Error saving token to database: " . $e->getMessage());
+            $this->logError('Error saving token to database: ' . $e->getMessage());
         }
     }
     
     /**
      * Verificar si el token está activo en la base de datos
      */
-    private function isTokenActiveInDatabase($token)
+    private function isTokenActiveInDatabase(string $jti): bool
     {
         try {
-            $tokenHash = hash('sha256', $token);
             $stmt = $this->pdo->prepare(
                 "SELECT id FROM api_tokens WHERE token_hash = ? AND is_active = TRUE AND expires_at > CURRENT_TIMESTAMP"
             );
-            $stmt->execute([$tokenHash]);
-            $result = $stmt->fetch();
-            
-            return $result !== false;
-            
+            $stmt->execute([hash('sha256', $jti)]);
+            return $stmt->fetch() !== false;
         } catch (Exception $e) {
-            $this->logError("Error checking token in database: " . $e->getMessage());
+            $this->logError('Error checking token in database: ' . $e->getMessage());
             return false;
         }
     }
@@ -257,20 +245,18 @@ class JWT
     /**
      * Actualizar último uso del token
      */
-    private function updateTokenLastUsed($token)
+    private function updateTokenLastUsed(string $jti): void
     {
         try {
-            $tokenHash = hash('sha256', $token);
             $stmt = $this->pdo->prepare(
                 "UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?"
             );
             $stmt->execute([
                 date('Y-m-d H:i:s'),
-                $tokenHash
+                hash('sha256', $jti)
             ]);
-            
         } catch (Exception $e) {
-            $this->logError("Error updating token last used: " . $e->getMessage());
+            $this->logError('Error updating token last used: ' . $e->getMessage());
         }
     }
     

--- a/app/Jobs/DownloadRecordingJob.php
+++ b/app/Jobs/DownloadRecordingJob.php
@@ -1,7 +1,7 @@
 <?php
 namespace FlujosDimension\Jobs;
 
-use FlujosDimension\Services\RingoverService;
+use FlujosDimension\Services\CallService;
 use FlujosDimension\Repositories\CallRepository;
 use FlujosDimension\Repositories\AsyncTaskRepository;
 use FlujosDimension\Support\Validator;
@@ -10,7 +10,7 @@ use FlujosDimension\Core\Config;
 class DownloadRecordingJob implements JobInterface
 {
     public function __construct(
-        private RingoverService $ringover,
+        private CallService $ringover,
         private CallRepository $calls,
         private AsyncTaskRepository $tasks
     ) {}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "vlucas/phpdotenv": "^5.6",
     "symfony/http-foundation": "^7.3",
     "symfony/console": "^7.3",
-    "league/flysystem": "^3.0"
+    "league/flysystem": "^3.0",
+    "firebase/php-jwt": "^6.11"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ceea9dc241bd2057f495684e2ce4230",
+    "content-hash": "0379578968e22b20a545df6b1cb75024",
     "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
+        },
         {
             "name": "graham-campbell/result-type",
             "version": "v1.1.3",

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,8 @@ cp .env.example .env
    Edit `.env` and configure the database variables (`DB_HOST`, `DB_PORT`,
    `DB_NAME`, `DB_USER`, `DB_PASS`) and API credentials
    `RINGOVER_API_KEY`, `PIPEDRIVE_API_TOKEN`, `OPENAI_API_KEY`.
-   Also set `JWT_SECRET`. The value of `ADMIN_PASS` should be generated
+   Also set JWT keys: `JWT_KID`, `JWT_KEYS_CURRENT` and (optionally)
+   `JWT_KEYS_PREVIOUS`. The value of `ADMIN_PASS` should be generated
    with `password_hash`.
 3. **Import the database schema** located in `database/flujodimen_db.sql` into your MySQL/MariaDB server and
    then run the SQL scripts in `database/migrations/` to create the rate limiting and webhook deduplication

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -77,6 +77,8 @@ curl -X POST https://localhost/api/webhooks \
 - `PIPEDRIVE_API_TOKEN`: token de autenticación de Pipedrive.
 
 ### Seguridad y administración
-- `JWT_SECRET`: secreto para firmar tokens JWT.
+- `JWT_KID`: identificador de la clave activa.
+- `JWT_KEYS_CURRENT`: clave actual para firmar tokens JWT.
+- `JWT_KEYS_PREVIOUS`: claves anteriores aceptadas durante la rotación.
 - `ADMIN_USER`: usuario del panel de administración.
 - `ADMIN_PASS`: contraseña encriptada para el panel.

--- a/docs/ringover_sync.md
+++ b/docs/ringover_sync.md
@@ -57,3 +57,17 @@ analizados se restablece a `0`.
    columna `voicemail_url` y el campo `pending_analysis`.
 2. Ejecutar `phpunit` para validar los cambios.
 3. Configurar los flujos de n8n con parámetros `page` y `limit`.
+
+## Ejemplos de uso con curl
+
+Autenticando una sesión en `localhost` con cookie `PHPSESSID=test` y token CSRF `tok`:
+
+```bash
+# Sincronización básica
+curl -H "Cookie: PHPSESSID=test" -H "X-Correlation-Id: demo" \\
+     -d "csrf_token=tok" http://localhost:8000/api/sync_ringover.php
+
+# Ejemplo con error de validación
+curl -H "Cookie: PHPSESSID=test" -H "X-Correlation-Id: demo" \\
+     -d "csrf_token=tok&download=abc" http://localhost:8000/api/sync_ringover.php
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,8 @@
     <env name="DB_PASS" value="pass"/>
     <env name="ADMIN_USER" value="admin"/>
     <env name="ADMIN_PASS" value="secret"/>
-    <env name="JWT_SECRET" value="key"/>
+    <env name="JWT_KEYS_CURRENT" value="key"/>
+    <env name="JWT_KID" value="test"/>
   </php>
   <source>
     <include>

--- a/tests/AdminApiTest.php
+++ b/tests/AdminApiTest.php
@@ -13,7 +13,8 @@ class AdminApiTest extends TestCase
 
     protected function setUp(): void
     {
-        $_ENV['JWT_SECRET'] = 'secret';
+        $_ENV['JWT_KEYS_CURRENT'] = 'secret';
+        $_ENV['JWT_KID'] = 'test';
         $this->container = new Container();
 
         $this->container->instance('analyticsService', new class {

--- a/tests/AuthRequirementTest.php
+++ b/tests/AuthRequirementTest.php
@@ -17,7 +17,8 @@ class AuthRequirementTest extends TestCase
     public function testControllerRequiresValidToken()
     {
         $config = Config::getInstance();
-        $config->set('JWT_SECRET', 'secret');
+        $config->set('JWT_KEYS_CURRENT', 'secret');
+        $config->set('JWT_KID', 'test');
         $config->set('JWT_EXPIRATION_HOURS', '1');
 
         $pdo = new PDO('sqlite::memory:');

--- a/tests/JwtTest.php
+++ b/tests/JwtTest.php
@@ -13,7 +13,8 @@ class JwtTest extends TestCase
     protected function setUp(): void
     {
         $config = Config::getInstance();
-        $config->set('JWT_SECRET', 'secret');
+        $config->set('JWT_KEYS_CURRENT', 'secret');
+        $config->set('JWT_KID', 'test');
         $config->set('JWT_EXPIRATION_HOURS', '1');
 
         $this->pdo = new PDO('sqlite::memory:');
@@ -36,6 +37,8 @@ class JwtTest extends TestCase
         $jwt = new JWT($this->pdo);
         $token = $jwt->generateToken(['user_id' => 5]);
         $this->assertMatchesRegularExpression('/^[^.]+\.[^.]+\.[^.]+$/', $token);
+        $header = json_decode(base64_decode(explode('.', $token)[0]), true);
+        $this->assertSame('test', $header['kid']);
         $payload = $jwt->validateToken($token);
         $this->assertSame(5, $payload['user_id']);
     }

--- a/tests/N8nControllerTest.php
+++ b/tests/N8nControllerTest.php
@@ -16,7 +16,8 @@ class N8nControllerTest extends TestCase
     private function makeContainer(): Container
     {
         $config = Config::getInstance();
-        $config->set('JWT_SECRET', 'secret');
+        $config->set('JWT_KEYS_CURRENT', 'secret');
+        $config->set('JWT_KID', 'test');
         $config->set('JWT_EXPIRATION_HOURS', '1');
 
         $pdo = new PDO('sqlite::memory:');


### PR DESCRIPTION
## Summary
- replace deprecated RingoverService references with CallService
- unify `admin/api/sync_ringover.php` output and add curl examples
- integrate firebase/php-jwt with key rotation and jti-based revocation

## Testing
- `php -l app/Jobs/DownloadRecordingJob.php admin/api/sync_ringover.php app/Console/SyncHourlyCommand.php`
- `grep -R "Services\\RingoverService" -n app/Jobs app/Console admin`
- `./vendor/bin/phpunit` *(fails: errors and failures)*
- `php -l admin/api/sync_ringover.php`
- `curl -H "Cookie: PHPSESSID=test" -H "X-Correlation-Id: abc" -d "csrf_token=tok" http://127.0.0.1:8000/api/sync_ringover.php`
- `curl -H "Cookie: PHPSESSID=test" -H "X-Correlation-Id: abc" -d "csrf_token=tok&download=abc" http://127.0.0.1:8000/api/sync_ringover.php`
- `composer require firebase/php-jwt`
- `php -l app/Core/JWT.php app/Core/Config.php app/Controllers/ConfigController.php admin/views/env_editor.php`
- `./vendor/bin/phpunit` *(fails: errors and failures)*


------
https://chatgpt.com/codex/tasks/task_e_689c644f3afc832a8d10b87f8edbda4c