### PR TITLE
feat: rate limit config and basic queue worker

### DIFF
--- a/app/Console/QueueWorkCommand.php
+++ b/app/Console/QueueWorkCommand.php
@@ -1,0 +1,98 @@
+<?php
+namespace FlujosDimension\Console;
+
+use FlujosDimension\Core\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use PDO;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class QueueWorkCommand extends Command
+{
+    protected static $defaultName = 'queue:work';
+
+    private Application $app;
+
+    public function __construct(?Application $app = null)
+    {
+        parent::__construct();
+        $this->app = $app ?? new Application();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Process async tasks queue');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $container = $this->app->getContainer();
+        /** @var PDO $pdo */
+        $pdo = $container->resolve(PDO::class);
+        /** @var LoggerInterface $logger */
+        $logger = $container->resolve('logger');
+
+        while (true) {
+            $task = $this->fetchTask($pdo);
+            if (!$task) {
+                sleep(5);
+                continue;
+            }
+
+            $this->reserveTask($pdo, (int)$task['id']);
+
+            try {
+                $job = $container->make($task['task_type']);
+                if (!method_exists($job, 'handle')) {
+                    throw new \RuntimeException('Job missing handle method');
+                }
+                $payload = json_decode($task['task_data'], true) ?? [];
+                $job->handle($payload);
+                $this->deleteTask($pdo, (int)$task['id']);
+                $logger->info('queue_job_success', ['task_id' => $task['task_id']]);
+            } catch (Throwable $e) {
+                $this->handleFailure($pdo, $task, $e, $logger);
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function fetchTask(PDO $pdo): ?array
+    {
+        $stmt = $pdo->prepare("SELECT * FROM async_tasks WHERE dlq = 0 AND visible_at <= NOW() AND (reserved_at IS NULL OR reserved_at < DATE_SUB(NOW(), INTERVAL 60 SECOND)) ORDER BY priority ASC, id ASC LIMIT 1");
+        $stmt->execute();
+        $task = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $task ?: null;
+    }
+
+    private function reserveTask(PDO $pdo, int $id): void
+    {
+        $stmt = $pdo->prepare("UPDATE async_tasks SET reserved_at = NOW(), attempts = attempts + 1 WHERE id = :id");
+        $stmt->execute([':id' => $id]);
+    }
+
+    private function deleteTask(PDO $pdo, int $id): void
+    {
+        $pdo->prepare('DELETE FROM async_tasks WHERE id = :id')->execute([':id' => $id]);
+    }
+
+    private function handleFailure(PDO $pdo, array $task, Throwable $e, LoggerInterface $logger): void
+    {
+        $attempts = (int)$task['attempts'] + 1;
+        $maxAttempts = (int)$task['max_attempts'];
+        if ($attempts >= $maxAttempts) {
+            $pdo->prepare('UPDATE async_tasks SET dlq = 1, error_reason = :err, reserved_at = NULL WHERE id = :id')
+                ->execute([':err' => $e->getMessage(), ':id' => $task['id']]);
+            $logger->error('queue_job_failed_dlq', ['task_id' => $task['task_id'], 'error' => $e->getMessage()]);
+            return;
+        }
+
+        $delay = $attempts * (int)$task['retry_backoff_sec'];
+        $pdo->prepare('UPDATE async_tasks SET reserved_at = NULL, visible_at = DATE_ADD(NOW(), INTERVAL :delay SECOND) WHERE id = :id')
+            ->execute([':delay' => $delay, ':id' => $task['id']]);
+        $logger->warning('queue_job_retry', ['task_id' => $task['task_id'], 'delay' => $delay, 'error' => $e->getMessage()]);
+    }
+}

--- a/app/Repositories/AsyncTaskRepository.php
+++ b/app/Repositories/AsyncTaskRepository.php
@@ -11,7 +11,7 @@ class AsyncTaskRepository
      * Enqueue a new async task.
      * @param array<string,mixed> $data
      */
-    public function enqueue(string $taskType, array $data, int $priority = 5, ?string $correlationId = null): string
+    public function enqueue(string $taskType, array $data, int $priority = 5, ?string $correlationId = null, int $maxAttempts = 3, int $retryBackoffSec = 60): string
     {
         $taskId = bin2hex(random_bytes(16));
         $now = date('Y-m-d H:i:s');
@@ -21,13 +21,15 @@ class AsyncTaskRepository
             $data['correlation_id'] = $correlationId;
         }
         
-        $stmt = $this->db->prepare('INSERT INTO async_tasks (task_id, task_type, task_data, priority, status, attempts, scheduled_at, created_at, correlation_id) VALUES (:task_id,:task_type,:task_data,:priority,\'pending\',0,:scheduled_at,:created_at,:correlation_id)');
+        $stmt = $this->db->prepare('INSERT INTO async_tasks (task_id, task_type, task_data, priority, status, attempts, visible_at, reserved_at, error_reason, dlq, max_attempts, retry_backoff_sec, created_at, correlation_id) VALUES (:task_id,:task_type,:task_data,:priority,\'pending\',0,:visible_at,NULL,NULL,0,:max_attempts,:retry_backoff_sec,:created_at,:correlation_id)');
         $stmt->execute([
             ':task_id' => $taskId,
             ':task_type' => $taskType,
             ':task_data' => json_encode($data, JSON_THROW_ON_ERROR),
             ':priority' => $priority,
-            ':scheduled_at' => $now,
+            ':visible_at' => $now,
+            ':max_attempts' => $maxAttempts,
+            ':retry_backoff_sec' => $retryBackoffSec,
             ':created_at' => $now,
             ':correlation_id' => $correlationId,
         ]);

--- a/bin/console
+++ b/bin/console
@@ -5,8 +5,10 @@ require __DIR__ . '/../vendor/autoload.php';
 use Symfony\Component\Console\Application;
 use FlujosDimension\Console\SyncHourlyCommand;
 use FlujosDimension\Console\TokenCleanupCommand;
+use FlujosDimension\Console\QueueWorkCommand;
 
 $application = new Application('FlujosDimension CLI');
 $application->add(new SyncHourlyCommand());
 $application->add(new TokenCleanupCommand());
+$application->add(new QueueWorkCommand());
 $application->run();

--- a/database/migrations/007_create_rate_limit_config.sql
+++ b/database/migrations/007_create_rate_limit_config.sql
@@ -1,0 +1,25 @@
+-- Migration: 007_create_rate_limit_config.sql
+-- Description: Create rate_limit_config table for per-service rate limiting policies
+-- Date: 2025-08-20
+
+CREATE TABLE IF NOT EXISTS rate_limit_config (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  service_name VARCHAR(50) NOT NULL,
+  max_requests_per_minute INT NOT NULL DEFAULT 60,
+  max_requests_per_hour INT NOT NULL DEFAULT 1000,
+  backoff_base_delay INT NOT NULL DEFAULT 1,
+  backoff_multiplier DECIMAL(3,2) NOT NULL DEFAULT 2.00,
+  max_retries INT NOT NULL DEFAULT 3,
+  max_backoff_delay INT NOT NULL DEFAULT 60,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_service_name (service_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Rate limit policies per external service';
+
+INSERT IGNORE INTO rate_limit_config (service_name, max_requests_per_minute, max_requests_per_hour, backoff_base_delay, backoff_multiplier, max_retries, max_backoff_delay, created_at)
+VALUES
+  ('openai', 10, 50, 1, 2.00, 3, 60, NOW()),
+  ('pipedrive', 30, 200, 1, 2.00, 3, 60, NOW()),
+  ('ringover', 50, 300, 1, 2.00, 3, 60, NOW()),
+  ('default', 20, 100, 1, 2.00, 3, 60, NOW());

--- a/database/migrations/008_alter_async_tasks.sql
+++ b/database/migrations/008_alter_async_tasks.sql
@@ -1,0 +1,11 @@
+-- Migration: 008_alter_async_tasks.sql
+-- Description: Add visibility, reservation and DLQ fields to async_tasks table
+-- Date: 2025-08-20
+
+ALTER TABLE async_tasks
+  ADD COLUMN visible_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER attempts,
+  ADD COLUMN reserved_at TIMESTAMP NULL DEFAULT NULL AFTER visible_at,
+  ADD COLUMN error_reason TEXT NULL AFTER reserved_at,
+  ADD COLUMN dlq TINYINT(1) NOT NULL DEFAULT 0 AFTER error_reason,
+  ADD COLUMN max_attempts INT NOT NULL DEFAULT 3 AFTER dlq,
+  ADD COLUMN retry_backoff_sec INT NOT NULL DEFAULT 60 AFTER max_attempts;

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use FlujosDimension\Core\RateLimiter;
+use PDO;
+
+class RateLimiterTest extends TestCase
+{
+    public function testUsesDatabaseConfig(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE rate_limit_buckets (id INTEGER PRIMARY KEY AUTOINCREMENT, bucket_key TEXT, tokens REAL, capacity INTEGER, last_refill INTEGER, created_at INTEGER)');
+        $pdo->exec('CREATE TABLE rate_limit_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, bucket_key TEXT, action TEXT, tokens_requested INTEGER, tokens_remaining REAL, correlation_id TEXT, ip_address TEXT, user_agent TEXT, created_at TEXT)');
+        $pdo->exec('CREATE TABLE rate_limit_config (service_name TEXT UNIQUE, max_requests_per_minute INTEGER, max_requests_per_hour INTEGER, backoff_base_delay INTEGER, backoff_multiplier REAL, max_retries INTEGER, max_backoff_delay INTEGER, created_at TEXT, updated_at TEXT)');
+        $pdo->exec("INSERT INTO rate_limit_config (service_name, max_requests_per_minute, max_requests_per_hour, backoff_base_delay, backoff_multiplier, max_retries, max_backoff_delay, created_at, updated_at) VALUES ('openai',120,1000,1,2,3,60,datetime('now'),datetime('now'))");
+
+        $rl = new RateLimiter($pdo);
+        $status = $rl->isAllowed('openai:api');
+        $this->assertSame(120, $status['capacity']);
+        $this->assertSame(2.0, $status['refill_rate']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `rate_limit_config` table and hook rate limiter to DB policies
- extend `async_tasks` with visibility/reservation fields and add queue worker command

## Testing
- `vendor/bin/phpunit tests/RateLimiterTest.php`
- `vendor/bin/phpunit tests/RingoverWebhookControllerTest.php` *(fails: TypeError from WebhookDeduplicator requiring PDO)*

------
https://chatgpt.com/codex/tasks/task_e_689c734e6088832ab4f5c0508ecd9c59